### PR TITLE
Fix pickling/unpickling of Dataset instances.

### DIFF
--- a/tablib/core25.py
+++ b/tablib/core25.py
@@ -35,7 +35,7 @@ __docformat__ = u'restructuredtext'
 class Row(object):
     u"""Internal Row object. Mainly used for filtering."""
 
-    __slots__ = [u'tuple', u'_row', u'tags']
+    __slots__ = [ u'_row', u'tags']
 
     def __init__(self, row=list(), tags=list()):
         self._row = list(row)
@@ -63,7 +63,14 @@ class Row(object):
         del self._row[i]
 
     def __getstate__(self):
-        return {slot: [getattr(self, slot) for slot in self.__slots__]}
+
+        slots = dict()
+
+        for slot in self.__slots__:
+            attribute = getattr(self, slot)
+            slots[slot] = attribute
+
+        return slots
 
     def __setstate__(self, state):
         for (k, v) in list(state.items()): setattr(self, k, v)


### PR DESCRIPTION
This pull request is to fix pickling / unpickling of Row within Dataset. **getstate** resembled a dictionary comprehension (Python 2.7+) but it wasn't, and it caused wrong values to be pickled, leading to unusable objects after restoring.

This patch fixes the issues. All unit tests still pass.
