### PR TITLE
Fix pickling (again). Unit tests still pass.

### DIFF
--- a/tablib/core.py
+++ b/tablib/core.py
@@ -29,7 +29,7 @@ __docformat__ = 'restructuredtext'
 class Row(object):
     """Internal Row object. Mainly used for filtering."""
 
-    __slots__ = ['tuple', '_row', 'tags']
+    __slots__ = ['_row', 'tags']
 
     def __init__(self, row=list(), tags=list()):
         self._row = list(row)


### PR DESCRIPTION
This pull request fixes picking in tablib. The previous statement looked like a dictionary comprehension, but not quite, and that leads to AttributeErrors when unpickling. 

This enables again the use of tablib with parallel processing, like with multiprocessing or Parallel Python (and the main reason I fixed this). 
