### PR TITLE
Add detect function in _xls. Update yaml, csv, and tsv detection functio...

### DIFF
--- a/tablib/formats/_csv.py
+++ b/tablib/formats/_csv.py
@@ -51,5 +51,5 @@ def detect(stream):
     try:
         csv.Sniffer().sniff(stream)
         return True
-    except csv.Error:
+    except (csv.Error, TypeError):
         return False

--- a/tablib/formats/_tsv.py
+++ b/tablib/formats/_tsv.py
@@ -55,5 +55,5 @@ def detect(stream):
     try:
         csv.Sniffer().sniff(stream, delimiters='\t')
         return True
-    except csv.Error:
+    except (csv.Error, TypeError):
         return False

--- a/tablib/formats/_xls.py
+++ b/tablib/formats/_xls.py
@@ -6,6 +6,8 @@
 import sys
 
 from tablib.compat import BytesIO, xlwt
+from tablib.packages import xlrd
+from tablib.packages.xlrd.biffh import XLRDError
 import tablib
 
 title = 'xls'
@@ -15,6 +17,24 @@ extentions = ('xls',)
 wrap = xlwt.easyxf("alignment: wrap on")
 bold = xlwt.easyxf("font: bold on")
 
+
+def detect(stream):
+    """Returns True if given stream is a readable excel file."""
+    try:
+        xlrd.open_workbook(file_contents=stream)
+        return True
+    except (TypeError, XLRDError):
+        pass 
+    try:
+        xlrd.open_workbook(file_contents=stream.read())
+        return True
+    except (AttributeError, XLRDError):
+        pass
+    try:
+        xlrd.open_workbook(filename=stream)
+        return True
+    except:
+        return False
 
 
 def export_set(dataset):

--- a/tablib/formats/_yaml.py
+++ b/tablib/formats/_yaml.py
@@ -60,5 +60,5 @@ def detect(stream):
             return True
         else:
             return False
-    except yaml.parser.ParserError:
+    except (yaml.parser.ParserError, yaml.reader.ReaderError):
         return False


### PR DESCRIPTION
The new _xls module doesn't have a detect function. I added one that deals with filenames, open files, or a bytestream as an acceptable 'stream' argument. I also updated the detect functions for yaml, csv, and tsv so they didn't bomb out when provided with invalid input (like an .xls file).
