### PR TITLE
don't use ExcelWriter with databook

### DIFF
--- a/tablib/formats/_xlsx.py
+++ b/tablib/formats/_xlsx.py
@@ -41,7 +41,6 @@ def export_book(databook):
     """Returns XLSX representation of DataBook."""
 
     wb = Workbook()
-    ew = ExcelWriter(workbook = wb)
     for i, dset in enumerate(databook._datasets):
         ws = wb.create_sheet()
         ws.title = dset.title if dset.title else 'Sheet%s' % (i)
@@ -50,7 +49,7 @@ def export_book(databook):
 
 
     stream = BytesIO()
-    ew.save(stream)
+    wb.save(stream)
     return stream.getvalue()
 
 


### PR DESCRIPTION
I've noticed that using ExcelWriter in databook gives an KeyError. Looked around a bit in the openpyxl code and found the comment that ExcelWriter shouldn't be used, so I've changed it.

https://bitbucket.org/ericgazoni/openpyxl/src/638995eb271c/openpyxl/workbook.py

``` python
def save(self, filename):
        """Save the current workbook under the given `filename`. 
        Use this function instead of using an `ExcelWriter`.
```
