### PR TITLE
Tweak setup.py for py.test (pytest?)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if sys.argv[-1] == 'test':
         print('py.test required.')
         sys.exit(1)
 
-    os.system('pytest test_tablib.py')
+    os.system('py.test test_tablib.py')
     sys.exit()
 
 setup(
@@ -70,4 +70,5 @@ setup(
         'Programming Language :: Python :: 3.1',
         'Programming Language :: Python :: 3.2',
     ),
+    tests_require=['pytest'],
 )


### PR DESCRIPTION
On my system, it's `py.test`. Is it called `pytest` on others?

```
(tablib.venv)[last: 0] marca@SCML-MarcA:~/dev/git-repos/tablib$ pip freeze
py==1.4.7
pytest==2.2.3
wsgiref==0.1.2
(tablib.venv)[last: 0] marca@SCML-MarcA:~/dev/git-repos/tablib$ which pytest
(tablib.venv)[last: 0] marca@SCML-MarcA:~/dev/git-repos/tablib$ which py.test
/Users/marca/dev/git-repos/tablib/tablib.venv/bin/py.test
```
