### PR TITLE
Remove __init__ from slots in ExcelFormula.py for Python 3.3 compatibility

### DIFF
--- a/tablib/packages/xlwt3/ExcelFormula.py
+++ b/tablib/packages/xlwt3/ExcelFormula.py
@@ -4,7 +4,7 @@ from .antlr import ANTLRException
 
 
 class Formula(object):
-    __slots__ = ["__init__",  "__s", "__parser", "__sheet_refs", "__xcall_refs"]
+    __slots__ = ["__s", "__parser", "__sheet_refs", "__xcall_refs"]
 
 
     def __init__(self, s):


### PR DESCRIPTION
This patch makes tablib install correctly using pip under Python 3.3. It looks like 3.3 tightened up restrictions on what can go into **slots**.
