### PR TITLE
Update url for pip vs easy_install in docs/install

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -22,7 +22,7 @@ or, with `easy_install <http://pypi.python.org/pypi/setuptools>`_::
 
     $ easy_install tablib
 
-But, you really `shouldn't do that <http://www.pip-installer.org/en/latest/index.html#pip-compared-to-easy-install>`_.
+But, you really `shouldn't do that <http://www.pip-installer.org/en/latest/other-tools.html#pip-compared-to-easy-install>`_.
 
 
 


### PR DESCRIPTION
The page referred to in the pip documentation has been moved. It discusses the features that `pip` offers over `easy_install`.
