### PR TITLE
Remove wrong/unused import so tests will actually run

### DIFF
--- a/test_tablib.py
+++ b/test_tablib.py
@@ -5,7 +5,6 @@
 
 import unittest
 import sys
-import openpyxl
 import os
 import tablib
 from tablib.compat import markup, unicode


### PR DESCRIPTION
For some reason test_tablib.py has 'import openpyxml' although it is not used, and if it was it should be 'from tablib.packages import openpyxml'. Anyway this import error is meaning none of the tests are running.
