### PR TITLE
Write the example file reliably in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,8 @@ EXCEL!
 ++++++
 ::
 
-	>>> open('people.xls', 'wb').write(data.xls)
+	>>> with open('people.xls', 'wb') as f:
+	...     f.write(data.xls)
 
 It's that easy.
 


### PR DESCRIPTION
The previous way doesn't work on PyPy or Jython, and emits warnings in recent python3s.
