### PR TITLE
using readlines() in _tsv.py fixes a small bug. 

### DIFF
--- a/tablib/formats/_tsv.py
+++ b/tablib/formats/_tsv.py
@@ -34,9 +34,9 @@ def import_set(dset, in_stream, headers=True):
     dset.wipe()
 
     if is_py3:
-        rows = csv.reader(in_stream.split('\r\n'), delimiter='\t')
+        rows = csv.reader(in_stream.splitlines(), delimiter='\t')
     else:
-        rows = csv.reader(in_stream.split('\r\n'), delimiter='\t',
+        rows = csv.reader(in_stream.splitlines(), delimiter='\t',
                           encoding=DEFAULT_ENCODING)
 
     for i, row in enumerate(rows):


### PR DESCRIPTION
The current documentation gives an example that causes an error, because its using \n for line endings. The error message suggested that I should be using universal line endings, but the function was using split('\r\n').  I changed it to use readlines()  and that seems to clear it up. I only tested in python 2.7 on linux. 

Documentation I was referring to:

data = tablib.Dataset()
data.tsv = 'age     first_name      last_name\n90   John    Adams'
