### PR TITLE
Remove XLSX empty sheet on export_book

### DIFF
--- a/tablib/formats/_xlsx.py
+++ b/tablib/formats/_xlsx.py
@@ -41,6 +41,7 @@ def export_book(databook):
     """Returns XLSX representation of DataBook."""
 
     wb = Workbook()
+    wb.worksheets = []
     ew = ExcelWriter(workbook = wb)
     for i, dset in enumerate(databook._datasets):
         ws = wb.create_sheet()


### PR DESCRIPTION
XLSX export with an empty sheet because `Workbook()` create a sheet on init. This patch clean worksheets before add datasets.
