### PR TITLE
Remove interspersed tabs

### DIFF
--- a/tablib/formats/_html.py
+++ b/tablib/formats/_html.py
@@ -13,7 +13,6 @@ else:
     from cStringIO import StringIO
     from tablib.packages import markup
 
-import tablib
 
 BOOK_ENDINGS = 'h3'
 


### PR DESCRIPTION
Fixes some code that has both tabs & spaces for indentation.

http://www.python.org/dev/peps/pep-0008/#tabs-or-spaces
