### PR TITLE
Use InvalidFileException to fix the test

### DIFF
--- a/tablib/formats/_xlsx.py
+++ b/tablib/formats/_xlsx.py
@@ -30,7 +30,7 @@ def detect(stream):
     try:
         openpyxl.reader.excel.load_workbook(stream)
         return True
-    except TypeError:
+    except openpyxl.shared.exc.InvalidFileException:
         pass
 
 def export_set(dataset):


### PR DESCRIPTION
```
python test_tablib.py 
......E.....................................
======================================================================
ERROR: test_auto_format_detect (__main__.TablibTestCase)
Test auto format detection.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_tablib.py", line 503, in test_auto_format_detect
    self.assertEqual(tablib.detect(_bunk)[0], None)
  File "/home/eduard/Projectes/tablib/tablib/core.py", line 996, in detect
    if fmt.detect(stream):
  File "/home/eduard/Projectes/tablib/tablib/formats/_xlsx.py", line 31, in detect
    openpyxl.reader.excel.load_workbook(stream)
  File "/home/eduard/Projectes/tablib/tablib/packages/openpyxl/reader/excel.py", line 70, in load_workbook
    raise InvalidFileException()
InvalidFileException

----------------------------------------------------------------------
Ran 44 tests in 0.051s

FAILED (errors=1)
```
