### PR TITLE
allow csv fields to have multiple lines

### DIFF
--- a/tablib/formats/_csv.py
+++ b/tablib/formats/_csv.py
@@ -35,9 +35,9 @@ def import_set(dset, in_stream, headers=True):
     dset.wipe()
 
     if is_py3:
-        rows = csv.reader(in_stream.splitlines())
+        rows = csv.reader(StringIO(in_stream))
     else:
-        rows = csv.reader(in_stream.splitlines(), encoding=DEFAULT_ENCODING)
+        rows = csv.reader(StringIO(in_stream), encoding=DEFAULT_ENCODING)
     for i, row in enumerate(rows):
 
         if (i == 0) and (headers):

--- a/test_tablib.py
+++ b/test_tablib.py
@@ -421,6 +421,22 @@ class TablibTestCase(unittest.TestCase):
         self.assertEqual(_csv, data.csv)
 
 
+    def test_csv_import_set_with_newlines(self):
+        """Generate and import CSV set serialization when row values have
+        newlines."""
+        data.append(('Markdown\n=======',
+                     'A cool language\n\nwith paragraphs'))
+        data.append(('reStructedText\n==============',
+                     'Another cool language\n\nwith paragraphs'))
+        data.headers = ('title', 'body')
+
+        _csv = data.csv
+
+        data.csv = _csv
+
+        self.assertEqual(_csv, data.csv)
+
+
     def test_tsv_import_set(self):
         """Generate and import TSV set serialization."""
         data.append(self.john)


### PR DESCRIPTION
This is a potential fix for #143

I sometimes keep small amounts of content is csv files, and the content has newlines in it. As I mention in #143, the newlines get stripped out, even though they are quoted.
I noticed that the problem goes away when you give the csv reader an actual stream instead of a list of strings, so that is my offered solution. I would think it might be better to just change the API so `import_set` takes a stream instead of a string, but I assume there are good reasons to have it this way.
