### PR TITLE
Support importing ragged CSV text into a Dataset

### DIFF
--- a/tablib/formats/_csv.py
+++ b/tablib/formats/_csv.py
@@ -31,15 +31,21 @@ def export_set(dataset):
 
 def import_set(dset, in_stream, headers=True):
     """Returns dataset from CSV stream."""
-
     dset.wipe()
+
+    lines = in_stream.splitlines()
+    reader = csv.reader(lines)
+    max_width = max(len(row) for row in reader)
+    del reader
 
     if is_py3:
         rows = csv.reader(StringIO(in_stream))
     else:
         rows = csv.reader(StringIO(in_stream), encoding=DEFAULT_ENCODING)
-    for i, row in enumerate(rows):
 
+    for i, row in enumerate(rows):
+        while(len(row) < max_width):
+            row.append('')
         if (i == 0) and (headers):
             dset.headers = row
         else:

--- a/tablib/formats/_csv.py
+++ b/tablib/formats/_csv.py
@@ -33,10 +33,11 @@ def import_set(dset, in_stream, headers=True):
     """Returns dataset from CSV stream."""
     dset.wipe()
 
+    # get width of widest row
     lines = in_stream.splitlines()
     reader = csv.reader(lines)
     max_width = max(len(row) for row in reader)
-    del reader
+    del lines, reader
 
     if is_py3:
         rows = csv.reader(StringIO(in_stream))
@@ -44,8 +45,9 @@ def import_set(dset, in_stream, headers=True):
         rows = csv.reader(StringIO(in_stream), encoding=DEFAULT_ENCODING)
 
     for i, row in enumerate(rows):
-        while(len(row) < max_width):
-            row.append('')
+        # fill in empty cells to make all rows match the width of the widest row
+        row.extend([''] * (max_width - len(row)))
+
         if (i == 0) and (headers):
             dset.headers = row
         else:

--- a/test_tablib.py
+++ b/test_tablib.py
@@ -438,8 +438,7 @@ class TablibTestCase(unittest.TestCase):
 
 
     def test_csv_import_set_ragged(self):
-        """Generate and import CSV set serialization when not all rows have
-        the same length.
+        """Import CSV set when not all rows have the same length.
         """
         # input has rows of length 3, 1, 0, and 2. output rows all have
         # length 3, and different line terminators.

--- a/test_tablib.py
+++ b/test_tablib.py
@@ -437,6 +437,19 @@ class TablibTestCase(unittest.TestCase):
         self.assertEqual(_csv, data.csv)
 
 
+    def test_csv_import_set_ragged(self):
+        """Generate and import CSV set serialization when not all rows have
+        the same length.
+        """
+        # input has rows of length 3, 1, 0, and 2. output rows all have
+        # length 3, and different line terminators.
+        input_csv = 'A,B,C\nD\n\nE,F\n'
+        output_csv = 'A,B,C\r\nD,,\r\n,,\r\nE,F,\r\n'
+
+        data.csv = input_csv
+
+        self.assertEqual(output_csv, data.csv)
+
     def test_tsv_import_set(self):
         """Generate and import TSV set serialization."""
         data.append(self.john)


### PR DESCRIPTION
This adds support for importing ragged CSV text into a Dataset as in issue #226.

In formats._csv.import_set, any rows shorter than the widest row in the input (including empty rows with 0 width) are extended with empty cells to give all rows the same width.
