### PR TITLE
HTML input: formats.html.import_set

### DIFF
--- a/tablib/formats/_html.py
+++ b/tablib/formats/_html.py
@@ -91,5 +91,3 @@ def import_set(dset, in_stream, **kwargs):
         dset.append(
             [cell.get_text() for cell in row.find_all('td', recursive=False)])
 
-    print dset
-

--- a/tablib/formats/_html.py
+++ b/tablib/formats/_html.py
@@ -71,7 +71,7 @@ def export_book(databook):
     return stream.getvalue().decode('utf-8')
 
 
-def import_set(dset, in_stream, headers=True, **kwargs):
+def import_set(dset, in_stream, **kwargs):
     dset.wipe()
     text = in_stream.read()
     tables = bs4.BeautifulSoup(markup=text).find_all('table')

--- a/test_tablib.py
+++ b/test_tablib.py
@@ -6,6 +6,9 @@ import json
 import unittest
 import sys
 import os
+
+from StringIO import StringIO
+
 import tablib
 from tablib.compat import markup, unicode, is_py3
 from tablib.core import Row
@@ -295,6 +298,56 @@ class TablibTestCase(unittest.TestCase):
         d = tablib.Dataset(['foo', None, 'bar'], headers=headers)
 
         self.assertEqual(html, d.html)
+
+    def test_html_import(self):
+        html = markup.page()
+        html.table.open()
+        html.thead.open()
+
+        html.tr(markup.oneliner.th(self.founders.headers))
+        html.thead.close()
+
+        for founder in self.founders:
+            html.tr(markup.oneliner.td(founder))
+
+        html.table.close()
+        html = StringIO(str(html))
+
+        data.html = html
+
+        self.assertEqual(['first_name', 'last_name', 'gpa'], data.headers)
+        self.assertEqual([
+            ('John', 'Adams', '90'),
+            ('George', 'Washington', '67'),
+            ('Thomas', 'Jefferson', '50'),
+        ], data[:])
+
+    def test_html_import_no_headers(self):
+        html = markup.page()
+        html.table.open()
+        html.thead.open()
+
+        for founder in self.founders:
+            html.tr(markup.oneliner.td(founder))
+
+        html.table.close()
+        html = StringIO(str(html))
+
+        data.html = html
+
+        self.assertEqual(None, data.headers)
+        self.assertEqual([
+            ('John', 'Adams', '90'),
+            ('George', 'Washington', '67'),
+            ('Thomas', 'Jefferson', '50'),
+        ], data[:])
+
+    def test_html_import_no_table(self):
+        html = StringIO(str(markup.page()))
+
+        with self.assertRaises(ValueError) as e:
+            data.html = html
+        self.assertEqual('Expected 1 table, found 0', e.exception.message)
 
     def test_latex_export(self):
         """LaTeX export"""


### PR DESCRIPTION
formats.html.import_set imports a Dataset from an HTML table.

It assumes there is exactly one table in the HTML document. (An import_book function would be more appropriate to handle multiple tables, but that doesn't seem very useful.) Headers are taken from <th> elements if they exist.

BeautifulSoup (bs4) is used for HTML parsing, assuming it's OK to add that dependency. I didn't add a copy of bs4 to the "packages" directory since I'm not sure if that is necessary, or why it was done with other dependencies. Alternately, it could be added as a requirement in setup.py. Which way would be best?
