### PR TITLE
Force default_flow_style for pyyaml safe_dump

### DIFF
--- a/src/tablib/formats/_yaml.py
+++ b/src/tablib/formats/_yaml.py
@@ -13,12 +13,12 @@ class YAMLFormat:
     def export_set(cls, dataset):
         """Returns YAML representation of Dataset."""
 
-        return yaml.safe_dump(dataset._package(ordered=False))
+        return yaml.safe_dump(dataset._package(ordered=False), default_flow_style=None)
 
     @classmethod
     def export_book(cls, databook):
         """Returns YAML representation of Databook."""
-        return yaml.safe_dump(databook._package(ordered=False))
+        return yaml.safe_dump(databook._package(ordered=False), default_flow_style=None)
 
     @classmethod
     def import_set(cls, dset, in_stream):

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1092,6 +1092,17 @@ class YAMLTests(BaseTestCase):
 
         self.assertEqual(_yaml, data.yaml)
 
+    def test_yaml_export(self):
+        """YAML export"""
+
+        expected = """\
+- {first_name: John, gpa: 90, last_name: Adams}
+- {first_name: George, gpa: 67, last_name: Washington}
+- {first_name: Thomas, gpa: 50, last_name: Jefferson}
+"""
+        output = self.founders.yaml
+        self.assertEqual(output, expected)
+
 
 class LatexTests(BaseTestCase):
     def test_latex_export(self):


### PR DESCRIPTION
Pyyaml 5.1 changed their default_flow_style for their *dump methods.
This patch is here to maintain a consistent behavior in the output before and after upgrading pyyaml to 5.1.
You can see more details in https://bugs.debian.org/934271