### PR TITLE
Test on Python 3.8 beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
     - python: 3.5
     - python: 3.6
     - python: 3.7
+    - python: 3.8-dev
 install:
   - pip install -r requirements.txt
 script: python test_tablib.py


### PR DESCRIPTION
Python 3.8.0 final is due out on **October 14th**, with the release candidate out now.

* https://discuss.python.org/t/currently-working-on-the-release-of-python-3-8-0rc1/2411

It's a good idea to test it out now, to avoid any big surprises in two weeks.
