### PR TITLE
Fix missing comma in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install = [
     'odfpy',
     'openpyxl>=2.4.0',
     'backports.csv;python_version<"3.0"',
-    'markuppy'
+    'markuppy',
     'xlrd',
     'xlwt',
     'pyyaml',


### PR DESCRIPTION
Missing comma in `setup.py` file causes an error while running the tests:
```
ERROR: Could not find a version that satisfies the requirement markuppyxlrd (from tablib==0.13.0) (from versions: none)
ERROR: No matching distribution found for markuppyxlrd (from tablib==0.13.0)
```
pip can't install `markuppyxlrd` (markuppy, xlrd)
