### PR TITLE
Test with pytest and send coverage to Codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+# .coveragerc to control coverage.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma:
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ junit-py27.xml
 # pyenv noise
 .python-version
 tablib.egg-info/*
+
+# Coverage
+.coverage
+htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 cache: pip
+
 matrix:
   include:
     - python: 2.7
@@ -7,6 +8,13 @@ matrix:
     - python: 3.6
     - python: 3.7
     - python: 3.8-dev
+
 install:
   - pip install -r requirements.txt
-script: python test_tablib.py
+  - pip install -U pytest pytest-cov
+
+script: pytest --cov tablib
+
+after_success:
+  - pip install -U codecov
+  - codecov

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Jazzband](https://jazzband.co/static/img/badge.svg)](https://jazzband.co/)
 [![Build Status](https://travis-ci.org/jazzband/tablib.svg?branch=master)](https://travis-ci.org/jazzband/tablib)
+[![codecov](https://codecov.io/gh/jazzband/tablib/branch/master/graph/badge.svg)](https://codecov.io/gh/jazzband/tablib)
 
     _____         ______  ___________ ______
     __  /_______ ____  /_ ___  /___(_)___  /_


### PR DESCRIPTION
Use pytest to test with coverage, and send the coverage to Codecov.

This will help ensure PRs maintain coverage and that new code is tested.

Coverage is currently 79%, which is pretty good.

Here's an example report on Codecov:

* https://codecov.io/gh/jazzband/tablib/tree/86a1b1dbe3e13b35a2133123ddfd212a44772daa/tablib