### PR TITLE
Test Windows, macOS and Linux on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.5, 3.6, 3.7]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox
+        python -m pip install  -e .
+
+    - name: Tox tests
+      shell: bash
+      # Drop the dot: py3.7-tests -> py37-tests
+      run: |
+        tox -e py`echo ${{ matrix.python-version }} | tr -d .`-tests


### PR DESCRIPTION
We currently run the tests on Linux on Travis CI, for Python 3.6-3.8.

This PR runs the tests for Windows, macOS and Linux on GitHub Actions, for Python 3.5-3.7.

Python 3.8 is not yet available:
* https://github.com/actions/setup-python/issues/30

We _could_ skip Linux tests here, but GitHub Actions gives 20 parallel jobs (compared to 5 with Travis) so it including these 3 jobs here won't slow it down.

These are the `py{35,36,37,38}-tests` from `tox.ini`.

The `py37-{docs,lint}` tests are not done here, they're done on Travis CI, but could be added here.

Example test run:

* https://github.com/hugovk/tablib/commit/e0e75ed43ca70622863d35bd37ef2d8bfea5d76b/checks?check_suite_id=272272605