### PR TITLE
Update testing: add docs + lint jobs; use pre-commit for linting

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,30 @@
+name: Docs and lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+        env:
+        - TOXENV: docs
+        - TOXENV: lint
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
+
+      - name: Tox
+        run: tox
+        env: ${{ matrix.env }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,15 @@ repos:
     hooks:
       - id: isort
         additional_dependencies: [toml]
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.4.2
+    hooks:
+      - id: python-check-blanket-noqa
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+      - id: isort
+        additional_dependencies: [toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v1.25.1
+    hooks:
+      - id: pyupgrade
+        args: ["--py3-plus"]
+
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     rev: v1.4.2
     hooks:
       - id: python-check-blanket-noqa
+      - id: rst-backticks
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 dist: xenial
 language: python
-cache: pip
+cache:
+  pip: true
+  directories:
+    - $HOME/.cache/pre-commit
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,24 @@
-language: python
-python:
-- 3.6
-- 3.7
-- 3.8
-cache: pip
 dist: xenial
+language: python
+cache: pip
+
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.8
+      env: TOXENV=docs
+    - python: 3.8
+      env: TOXENV=lint
+    - python: 3.8
+    - python: 3.7
+    - python: 3.6
+
 install: travis_retry pip install tox-travis
+
 script: tox
+
 after_success: bash <(curl -s https://codecov.io/bash)
+
 deploy:
   provider: pypi
   user: jazzband

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,11 @@ install: travis_retry pip install tox-travis
 
 script: tox
 
-after_success: bash <(curl -s https://codecov.io/bash)
+after_success:
+  - |
+    if [[ "$TOXENV" != "docs" && "$TOXENV" != "lint" ]]; then
+      bash <(curl -s https://codecov.io/bash)
+    fi
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: python
 cache:
   pip: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 recursive-include docs *
 recursive-include tests *
-include pyproject.toml pytest.ini tox.ini .coveragerc *.md LICENSE AUTHORS
+include pyproject.toml pytest.ini tox.ini .coveragerc .pre-commit-config.yaml *.md LICENSE AUTHORS
 prune docs/_build
 prune *.pyc
 prune __pycache__

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -162,7 +162,7 @@ make the format available.
 
 .. admonition:: Binary Warning
 
-    The `xls` file format is binary, so make sure to write in binary mode::
+    The ``xls`` file format is binary, so make sure to write in binary mode::
 
         with open('output.xls', 'wb') as f:
             f.write(data.export('xls'))
@@ -177,7 +177,7 @@ make the format available.
 
 .. admonition:: Binary Warning
 
-    The `xlsx` file format is binary, so make sure to write in binary mode::
+    The ``xlsx`` file format is binary, so make sure to write in binary mode::
 
         with open('output.xlsx', 'wb') as f:
             f.write(data.export('xlsx'))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 .. Tablib documentation master file, created by
    sphinx-quickstart on Tue Oct  5 15:25:21 2010.
    You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+   contain the root ``toctree`` directive.
 
 Tablib: Pythonic Tabular Datasets
 =================================

--- a/src/tablib/core.py
+++ b/src/tablib/core.py
@@ -411,7 +411,7 @@ class Dataset:
 
         fmt = registry.get_format(format)
         if not hasattr(fmt, 'import_set'):
-            raise UnsupportedFormat('Format {0} cannot be imported.'.format(format))
+            raise UnsupportedFormat('Format {} cannot be imported.'.format(format))
             
         if not import_set:
             raise UnsupportedFormat('Format {} cannot be imported.'.format(format))

--- a/src/tablib/formats/__init__.py
+++ b/src/tablib/formats/__init__.py
@@ -103,8 +103,7 @@ class Registry:
         self.register('rst', ReSTFormat())
 
     def formats(self):
-        for frm in self._formats.values():
-            yield frm
+        yield from self._formats.values()
 
     def get_format(self, key):
         if key not in self._formats:

--- a/tox.ini
+++ b/tox.ini
@@ -2,15 +2,11 @@
 usedevelop = true
 minversion = 2.4
 envlist =
-    py{35,36,37,38}-tests,
-    py37-{docs,lint}
+    docs
+    lint
+    py{35,36,37,38}
 
 [testenv]
-basepython =
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
-    py38: python3.8
 deps =
     tests: -rtests/requirements.txt
     docs: sphinx
@@ -19,8 +15,7 @@ commands =
     tests: pytest {posargs:tests}
     docs: sphinx-build -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 
-[testenv:py37-lint]
-basepython = python3.7
+[testenv:lint]
 deps =
     flake8
     # flake8-black
@@ -33,6 +28,7 @@ commands =
     check-manifest -v
     python setup.py sdist
     twine check dist/*
+skip_install = true
 
 [flake8]
 exclude =

--- a/tox.ini
+++ b/tox.ini
@@ -17,14 +17,14 @@ commands =
 
 [testenv:lint]
 deps =
+    check-manifest
     flake8
     # flake8-black
-    isort
+    pre-commit
     twine
-    check-manifest
 commands =
     # flake8 src/tablib tests/
-    isort --check-only --diff
+    pre-commit run --all-files
     check-manifest -v
     python setup.py sdist
     twine check dist/*


### PR DESCRIPTION

* Travis CI: Move docs and lint to their own build job for more parallelism, this way we have the max 5 jobs running at once, instead of 3, and can quickly see if, say, the linting step failed

* GitHub Actions: Add a workflow to run the lint and docs tests

* tox: move isort into pre-commit. See instructions below about pre-commit; for tox, and in the CI, it's `pre-commit run all files`. For the user, they can still run `tox -e lint` as before.

---

# pre-commit

pre-commit can be used locally to check files when committing. If problems are found, it stops the commit with an error message. Some tools also fix the problems they find.

Fail fast, fail early.

pre-commit is not for everyone, and it's not mandatory to run it locally. I didn't used to be keen, but now I find it really helpful. It's important it doesn't take too long to run.

Even if you don't run it locally, it's handy for grouping together many linters, and running on the CI.

Here are the main commands for local use.

```bash
# Do this just once to init a repo:
pre-commit install

# The first run can take a bit longer to set up, after that it's quick

# Then commit like normal, it’ll run the checks on only the staged files:
git commit -m "something"

# If you want to skip the pre-commit checks:
git commit -m "something" -n

# If you want to run on all files:
pre-commit run all-files

# Once in a while, check for new versions of your lint tools:
pre-commit autoupdate  # and then commit the updated config file

# Stop using it locally:
pre-commit uninstall
```

I added some extra handy linters, such as `check-yaml`, which is really handy to find syntax errors in, say, `.travis.yml` before pushing and trying to find out why nothing was built.

We can also add Black and Flake8 here, when we're ready.

`rst-backticks` found some problems, which I've fixed, and `pyupgrade` made a couple of upgrades, which are included.

