### PR TITLE
Fix NameError: name '_get_column_widths' is not defined

### DIFF
--- a/src/tablib/formats/_rst.py
+++ b/src/tablib/formats/_rst.py
@@ -113,7 +113,7 @@ class ReSTFormat:
         lines = []
         wrapper = TextWrapper()
         if column_widths is None:
-            column_widths = _get_column_widths(dataset, pad_len=2)
+            column_widths = cls._get_column_widths(dataset, pad_len=2)
         border = '  '.join(['=' * w for w in column_widths])
 
         lines.append(border)

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -660,6 +660,26 @@ class RSTTests(BaseTestCase):
             '==========  =========  ==='
         )
 
+    def test_rst_export_set_as_simple_table(self):
+        # Arrange
+        data = tablib.Dataset()
+        data.append(self.john)
+        data.headers = self.headers
+        fmt = registry.get_format("rst")
+
+        # Act
+        out = fmt.export_set_as_simple_table(data)
+
+        # Assert
+        self.assertEqual(
+            out,
+            "==========  =========  ===\n"
+            "first_name  last_name  gpa\n"
+            "==========  =========  ===\n"
+            "John        Adams      90 \n"
+            "==========  =========  ===",
+        )
+
 
 class CSVTests(BaseTestCase):
     def test_csv_format_detect(self):

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -660,7 +660,7 @@ class RSTTests(BaseTestCase):
             '==========  =========  ==='
         )
 
-    def test_rst_export_set_as_simple_table(self):
+    def test_rst_export_set(self):
         # Arrange
         data = tablib.Dataset()
         data.append(self.john)
@@ -668,11 +668,13 @@ class RSTTests(BaseTestCase):
         fmt = registry.get_format("rst")
 
         # Act
-        out = fmt.export_set_as_simple_table(data)
+        out1 = fmt.export_set(data)
+        out2 = fmt.export_set_as_simple_table(data)
 
         # Assert
+        self.assertEqual(out1, out2)
         self.assertEqual(
-            out,
+            out1,
             "==========  =========  ===\n"
             "first_name  last_name  gpa\n"
             "==========  =========  ===\n"


### PR DESCRIPTION
Found by Flake8: https://github.com/jazzband/tablib/pull/428.

Also test the similar case in `ReSTFormat.export_set`.
