### PR TITLE
Remove unnecessary MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-recursive-include docs *
-recursive-include tests *
-include pyproject.toml pytest.ini tox.ini .coveragerc .pre-commit-config.yaml *.md LICENSE AUTHORS
-prune docs/_build
-prune *.pyc
-prune __pycache__

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ commands =
 
 [testenv:lint]
 deps =
-    check-manifest
     flake8
     # flake8-black
     pre-commit
@@ -25,7 +24,6 @@ deps =
 commands =
     # flake8 src/tablib tests/
     pre-commit run --all-files
-    check-manifest -v
     python setup.py sdist
     twine check dist/*
 skip_install = true


### PR DESCRIPTION
When using setuptools_scm, MANIFEST.in is needed when we want to exclude tracked files, or include untracked files.

https://github.com/pypa/setuptools_scm/blob/master/README.rst#file-finders-hook-makes-most-of-manifestin-unnecessary

It doesn't look like we need those, and check-manifest causes the CI to sometimes fail when adding new files, which setuptools_scm will find anyway. 

Ping @jezdez 