### PR TITLE
CI: Update GHA config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,5 @@ jobs:
 
     - name: Tox tests
       shell: bash
-      # Drop the dot: py3.7 -> py37
       run: |
-        tox -e py`echo ${{ matrix.python-version }} | tr -d .`
+        tox -e py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.5, 3.6, 3.7, 3.8]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.25.2
+    rev: v1.26.2
     hooks:
       - id: pyupgrade
         args: ["--py3-plus"]
@@ -12,7 +12,7 @@ repos:
         additional_dependencies: [toml]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.2
+    rev: v1.4.4
     hooks:
       - id: python-check-blanket-noqa
       - id: rst-backticks


### PR DESCRIPTION
* There's no need for the "drop the dot" workaround, it will use the interpreter tox is installed to
* Also test on Python 3.8
* `pre-commit autoupdate`