### PR TITLE
Document upcoming breaking change in 2.0.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,14 @@
 # History
 
+## 1.1.0 (Unreleased)
+
+### Deprecations
+
+- Upcoming breaking change in Tablib 2.0.0: the `Row.lpush/rpush` logic is reversed.
+  `lpush` is appending while `rpush` and `append` are prepending. The broken behavior
+  will remain in Tablib 1.x and will be fixed (reversed) in Tablib 2.0.0 (#453). If you
+  count on the broken behavior, please update your code when you upgrade to Tablib 2.x.
+
 ## 1.0.0 (2020-01-13)
 
 ### Breaking changes


### PR DESCRIPTION
https://github.com/jazzband/tablib/pull/454 will fix the broken behaviour of `Row.lpush`, `rpush` and `append` and release it in Tablib 2.0.0.

Ahead of that breaking change, announce the upcoming break in Tablib 1.1.0.