### PR TITLE
WIP: preliminary support for XML, 2020

### DIFF
--- a/src/tablib/formats/__init__.py
+++ b/src/tablib/formats/__init__.py
@@ -11,6 +11,7 @@ from tablib.utils import normalize_input
 from ._csv import CSVFormat
 from ._json import JSONFormat
 from ._tsv import TSVFormat
+from ._xml import XMLFormat
 
 uninstalled_format_messages = {
     "cli": {"package_name": "tabulate package", "extras_name": "cli"},
@@ -110,6 +111,7 @@ class Registry:
         self.register('rst', 'tablib.formats._rst.ReSTFormat')
         if find_spec('tabulate'):
             self.register('cli', 'tablib.formats._cli.CLIFormat')
+        self.register('xml', XMLFormat())
 
     def formats(self):
         for key, frm in self._formats.items():

--- a/src/tablib/formats/_xml.py
+++ b/src/tablib/formats/_xml.py
@@ -1,0 +1,32 @@
+""" Tablib - XML support.
+"""
+
+import xml.etree.ElementTree as ET
+
+
+class XMLFormat:
+    title = 'xml'
+    extensions = ('xml',)
+
+    # TODO implement
+    # @classmethod
+    # def import_set(cls, dset, in_stream):
+    #     dset.wipe()
+
+    @classmethod
+    def export_set(cls, dataset):
+        root = ET.Element('dataset')
+
+        for row_index, row in enumerate(dataset.dict):
+            row_node = ET.Element('row')
+            tags = dataset._data[row_index].tags
+            if tags:
+                row_node.set('tags', ','.join(tags))
+            for header, value in row.items():
+                value_node = ET.Element(header)
+                value_node.text = str(value)
+                row_node.append(value_node)
+
+            root.append(row_node)
+
+        return ET.tostring(root).decode()

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1350,3 +1350,34 @@ class CliTests(BaseTestCase):
             '+---+---+---+\n| a | b | c |\n+---+---+---+',
             tablib.Dataset(['a', 'b', 'c']).export('cli', tablefmt='grid')
         )
+
+
+class XMLTests(BaseTestCase):
+    def test_xml_export(self):
+        """Verify exporting dataset object as XML."""
+
+        xml = '<dataset>'
+        for row in self.founders:
+            xml += '<row>'
+            for i, header in enumerate(self.founders.headers):
+                xml += '<{}>{}</{}>'.format(header, row[i], header)
+            xml += '</row>'
+        xml += '</dataset>'
+
+        self.assertEqual(xml, self.founders.xml)
+
+    def test_xml_export_row_with_tag(self):
+        """Verify exporting dataset with row tags object as XML."""
+
+        local_data = tablib.Dataset(headers=['A', 'B'])
+        local_data.append(('a', 'b'), tags=['tag 1', 'tag 2'])
+
+        xml = '<dataset>'
+        for row_index, row in enumerate(local_data):
+            xml += '<row tags="{}">'.format(','.join(local_data._data[row_index].tags))
+            for header_index, header in enumerate(local_data.headers):
+                xml += '<{}>{}</{}>'.format(header, row[header_index], header)
+            xml += '</row>'
+        xml += '</dataset>'
+
+        self.assertEqual(xml, local_data.xml)


### PR DESCRIPTION
Hi all.

Before I start, I'm aware of #224 but it is 4 years old and tablib has changed quite extensively since then (dropped Python 2 support, format extensions are now classes, etc) so I thought I'd have a got at it.

It's a WIP and only supports export of dataset, but it supports tags. 

The dataset 

```python
data = Dataset(headers=['first_name', 'last_name', 'gpa'])
data.append(('John', 'Adams', 90))
data.append(('George', 'Washington', 67), tags=['tag 1', 'tag 2'])
```

is exported as

```xml
<dataset>
    <row>
        <first_name>John</first_name>
        <last_name>Adams</last_name>
        <gpa>90</gpa>
    </row>
    <row tags="tag 1,tag 2">
        <first_name>George</first_name>
        <last_name>Washington</last_name>
        <gpa>67</gpa>
    </row>
</dataset>
```

I do have a question: Is there a proper way to access a row's tags while iterating over the dataset? The only I found is to use `enumerate` and then use the row's index to index into `_data` which of course if unfavorable.

```python
for row_index, row in enumerate(dataset.dict):
    tags = dataset._data[row_index].tags
```