### PR TITLE
Docs: Suggest quotes when pip installing with optional dependencies

### DIFF
--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -27,7 +27,7 @@ For example::
     dataset.export("cli", tablefmt="github")
     dataset.export("cli", tablefmt="grid")
 
-This format is optional, install Tablib with ``pip install tablib[cli]`` to
+This format is optional, install Tablib with ``pip install "tablib[cli]"`` to
 make the format available.
 
 csv
@@ -83,7 +83,7 @@ df (DataFrame)
 ==============
 
 Import/export using the pandas_ DataFrame format. This format is optional,
-install Tablib with ``pip install tablib[pandas]`` to make the format available.
+install Tablib with ``pip install "tablib[pandas]"`` to make the format available.
 
 .. _pandas: https://pandas.pydata.org/
 
@@ -94,7 +94,7 @@ The ``html`` format is currently export-only. The exports produce an HTML page
 with the data in a ``<table>``. If headers have been set, they will be used as
 table headers.
 
-This format is optional, install Tablib with ``pip install tablib[html]`` to
+This format is optional, install Tablib with ``pip install "tablib[html]"`` to
 make the format available.
 
 jira
@@ -132,7 +132,7 @@ ods
 Export data in OpenDocument Spreadsheet format. The ``ods`` format is currently
 export-only.
 
-This format is optional, install Tablib with ``pip install tablib[ods]`` to
+This format is optional, install Tablib with ``pip install "tablib[ods]"`` to
 make the format available.
 
 .. admonition:: Binary Warning
@@ -183,7 +183,7 @@ xls
 
 Import/export data in Legacy Excel Spreadsheet representation.
 
-This format is optional, install Tablib with ``pip install tablib[xls]`` to
+This format is optional, install Tablib with ``pip install "tablib[xls]"`` to
 make the format available.
 
 .. note::
@@ -203,7 +203,7 @@ xlsx
 
 Import/export data in Excel 07+ Spreadsheet representation.
 
-This format is optional, install Tablib with ``pip install tablib[xlsx]`` to
+This format is optional, install Tablib with ``pip install "tablib[xlsx]"`` to
 make the format available.
 
 .. note::
@@ -232,7 +232,7 @@ returned instead.
 
 Import assumes (for now) that headers exist.
 
-This format is optional, install Tablib with ``pip install tablib[yaml]`` to
+This format is optional, install Tablib with ``pip install "tablib[yaml]"`` to
 make the format available.
 
 .. _YAML: https://yaml.org

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -26,19 +26,19 @@ formats available:
 
 .. code-block:: console
 
-    $ pip install tablib[xlsx]
+    $ pip install "tablib[xlsx]"
 
 Or all possible formats:
 
 .. code-block:: console
 
-    $ pip install tablib[all]
+    $ pip install "tablib[all]"
 
 which is equivalent to:
 
 .. code-block:: console
 
-    $ pip install tablib[html, pandas, ods, xls, xlsx, yaml]
+    $ pip install "tablib[html, pandas, ods, xls, xlsx, yaml]"
 
 -------------------
 Download the Source

--- a/src/tablib/formats/__init__.py
+++ b/src/tablib/formats/__init__.py
@@ -122,7 +122,7 @@ class Registry:
             if key in uninstalled_format_messages:
                 raise UnsupportedFormat(
                     "The '{key}' format is not available. You may want to install the "
-                    "{package_name} (or `pip install tablib[{extras_name}]`).".format(
+                    "{package_name} (or `pip install \"tablib[{extras_name}]\"`).".format(
                         **uninstalled_format_messages[key], key=key
                     )
                 )

--- a/src/tablib/formats/_df.py
+++ b/src/tablib/formats/_df.py
@@ -30,7 +30,7 @@ class DataFrameFormat:
         if DataFrame is None:
             raise NotImplementedError(
                 'DataFrame Format requires `pandas` to be installed.'
-                ' Try `pip install tablib[pandas]`.')
+                ' Try `pip install "tablib[pandas]"`.')
         dataframe = DataFrame(dset.dict, columns=dset.headers)
         return dataframe
 

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -57,7 +57,7 @@ class TablibTestCase(BaseTestCase):
         # A known format but uninstalled
         del registry._formats['ods']
         msg = (r"The 'ods' format is not available. You may want to install the "
-               "odfpy package \\(or `pip install tablib\\[ods\\]`\\).")
+               "odfpy package \\(or `pip install \"tablib\\[ods\\]\"`\\).")
         with self.assertRaisesRegex(UnsupportedFormat, msg):
             data.export('ods')
 


### PR DESCRIPTION
Fixes https://github.com/jazzband/tablib/issues/473.

Some shells require quotes when using square brackets: `pip install "tablib[all]"`

I believe other shells work fine with quotes too, so let's include them in the docs for when people copy and paste.
