### PR TITLE
Docs: Add link to changelog/history

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -8,4 +8,5 @@
   <li><a href="https://pypi.org/project/tablib">Tablib @ PyPI</a></li>
   <li><a href="https://github.com/jazzband/tablib">Tablib @ GitHub</a></li>
   <li><a href="https://github.com/jazzband/tablib/issues">Issue Tracker</a></li>
+  <li><a href="https://github.com/jazzband/tablib/blob/master/HISTORY.md">Changelog</a></li>
 </ul>


### PR DESCRIPTION
Fixes https://github.com/jazzband/tablib/issues/468.

Added to the "Useful links" section in the sidebar:

![image](https://user-images.githubusercontent.com/1324225/98911028-a1b73980-24cc-11eb-8790-75a3cbe758c3.png)
