### PR TITLE
Move testing from Travis CI to GitHub Actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,10 @@
 language: python
-cache:
-  pip: true
-  directories:
-    - $HOME/.cache/pre-commit
-
-matrix:
-  fast_finish: true
-  include:
-    - python: 3.8
-      env: TOXENV=docs
-    - python: 3.8
-      env: TOXENV=lint
-    - python: 3.9
-    - python: 3.8
-    - python: 3.7
-    - python: 3.6
+cache: pip
+python: 3.7
 
 install: travis_retry pip install tox-travis
 
 script: tox
-
-after_success:
-  - |
-    if [[ "$TOXENV" != "docs" && "$TOXENV" != "lint" ]]; then
-      bash <(curl -s https://codecov.io/bash)
-    fi
 
 deploy:
   provider: pypi


### PR DESCRIPTION
Travis CI has a new pricing model which places limits on open source.

* https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
* https://www.jeffgeerling.com/blog/2020/travis-cis-new-pricing-plan-threw-wrench-my-open-source-works

Many projects are moving to GitHub Actions instead, let's do the same.

~We already have tests on GHA, just missing sending coverage to Codecov. Earlier it was tricky to do, but Codecov now have an action for this; added here.~ Done in #480.

---

We'll need to move deployment from Travis to GHA. We already got it working for another [Jazzband project](https://github.com/jazzband/prettytable/blob/master/.github/workflows/deploy.yml), but I'll do it in a followup PR.

So this one reduces the Travis testing to a single job.

---

~This also fixes a pytest warning:~ Done in #480.
