### PR TITLE
Upload coverage from GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,8 @@ jobs:
       shell: bash
       run: |
         tox -e py
+
+    - name: Upload coverage
+      uses: codecov/codecov-action@v1
+      with:
+        name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 norecursedirs = .git .*
 addopts = -rsxX --showlocals --tb=native --cov=tablib --cov=tests --cov-report xml --cov-report term --cov-report html
-python_paths = .


### PR DESCRIPTION
Subset of https://github.com/jazzband/tablib/pull/479.

---

We already have tests on GitHub Actions, but are missing sending coverage to Codecov. Earlier it was tricky to do, but Codecov now have an action for this; added here.

---

This also fixes a pytest warning:

```
=============================== warnings summary ===============================
.tox/py37/lib/python3.7/site-packages/_pytest/config/__init__.py:1230
  /home/travis/build/hugovk/tablib/.tox/py37/lib/python3.7/site-packages/_pytest/config/__init__.py:1230: PytestConfigWarning: Unknown config option: python_paths
  
    self._warn_or_fail_if_strict("Unknown config option: {}\n".format(key))
-- Docs: https://docs.pytest.org/en/stable/warnings.html
```