### PR TITLE
Better exceptions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,7 +30,6 @@ Databook Object
    :inherited-members:
 
 
-
 ---------
 Functions
 ---------
@@ -46,19 +45,8 @@ Exceptions
 ----------
 
 
-.. class:: InvalidDatasetType
-
-    You're trying to add something that doesn't quite look right.
-
-
-.. class:: InvalidDimensions
-
-    You're trying to add something that doesn't quite fit right.
-
-
-.. class:: UnsupportedFormat
-
-    You're trying to add something that doesn't quite taste right.
+.. automodule:: tablib.exceptions
+   :members:
 
 
 Now, go start some :ref:`Tablib Development <development>`.

--- a/src/tablib/exceptions.py
+++ b/src/tablib/exceptions.py
@@ -3,11 +3,11 @@ class TablibException(Exception):
 
 
 class InvalidDatasetType(TablibException, TypeError):
-    """Only Datasets can be added to a DataBook."""
+    """Only Datasets can be added to a Databook."""
 
 
 class InvalidDimensions(TablibException, ValueError):
-    """Invalid size."""
+    """The size of the column or row doesn't fit the table dimensions."""
 
 
 class InvalidDatasetIndex(TablibException, IndexError):
@@ -15,8 +15,8 @@ class InvalidDatasetIndex(TablibException, IndexError):
 
 
 class HeadersNeeded(TablibException, AttributeError):
-    """Header parameter must be given when appending a column in this Dataset."""
+    """Header parameter must be given when appending a column to this Dataset."""
 
 
 class UnsupportedFormat(TablibException, NotImplementedError):
-    """Format is not supported."""
+    """Format not supported."""

--- a/src/tablib/exceptions.py
+++ b/src/tablib/exceptions.py
@@ -1,18 +1,22 @@
-class InvalidDatasetType(Exception):
-    "Only Datasets can be added to a DataBook"
+class TablibException(Exception):
+    """Tablib common exception."""
 
 
-class InvalidDimensions(Exception):
-    "Invalid size"
+class InvalidDatasetType(TablibException, TypeError):
+    """Only Datasets can be added to a DataBook."""
 
 
-class InvalidDatasetIndex(Exception):
-    "Outside of Dataset size"
+class InvalidDimensions(TablibException, ValueError):
+    """Invalid size."""
 
 
-class HeadersNeeded(Exception):
-    "Header parameter must be given when appending a column in this Dataset."
+class InvalidDatasetIndex(TablibException, IndexError):
+    """Outside of Dataset size."""
 
 
-class UnsupportedFormat(NotImplementedError):
-    "Format is not supported"
+class HeadersNeeded(TablibException, AttributeError):
+    """Header parameter must be given when appending a column in this Dataset."""
+
+
+class UnsupportedFormat(TablibException, NotImplementedError):
+    """Format is not supported."""


### PR DESCRIPTION
It's best practise for libraries to have a common parent class for its custom exceptions so that they all can be easily catched.

This PR also refines the built-in exceptions inheritance and adds autodoc for the exceptions module.