### PR TITLE
Specify build backend for editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+build-backend = "setuptools.build_meta"
+
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Fixes the issue that showed up in https://github.com/jazzband/tablib/pull/500, also reproducible locally:

With the old pip==21.2.4 we could do `python -m pip install -e .` for an editable install.

Now, with new pip==21.3 we need to specify the build backend. See:

> * Support editable installs for projects that have a pyproject.toml and use a build backend that supports PEP 660. (#8212)

https://pip.pypa.io/en/stable/news/#features

See also https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/