### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        include:
+          # Only test 3.10 on Ubuntu, until pandas wheels are available
+          - { python-version: "3.10", os: ubuntu-latest }
 
     steps:
     - uses: actions/checkout@v2
@@ -48,6 +51,6 @@ jobs:
         tox -e py
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     python_requires='>=3.6',
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ minversion = 2.4
 envlist =
     docs
     lint
-    py{36,37,38,39}
+    py{36,37,38,39,310}
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.10 was released last week:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955

Only test 3.10 on Ubuntu for now, because binary wheels for pandas on macOS and Windows are not yet available and the build will fail.