### PR TITLE
Test Python 3.10 on all operating systems

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        include:
-          # Only test 3.10 on Ubuntu, until pandas wheels are available
-          - { python-version: "3.10", os: ubuntu-latest }
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Pandas wheels are now available for all operating systems, we can test them all now. 