### PR TITLE
Correct order of arguments to a regex call in safe_xlsx_sheet_title

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ Here is a list of passed and present much-appreciated contributors:
     Luke Lee
     Marc Abramowitz
     Marco Dallagiacoma
+    Maris Nartiss
     Mark Rogers
     Mark Walling
     Mathias Loesch

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -39,7 +39,7 @@ class XLSXFormat:
         """Returns XLSX representation of Dataset.
 
         If dataset.title contains characters which are considered invalid for an XLSX file
-        sheet name (http://www.excelcodex.com/2012/06/worksheets-naming-conventions/), it will
+        sheet name (http://www.excelcodex.com/2012/06/worksheets-naming-conventions/), they will
         be replaced with `invalid_char_subst`.
         """
         wb = Workbook()
@@ -61,7 +61,7 @@ class XLSXFormat:
         """Returns XLSX representation of DataBook.
 
         If dataset.title contains characters which are considered invalid for an XLSX file
-        sheet name (http://www.excelcodex.com/2012/06/worksheets-naming-conventions/), it will
+        sheet name (http://www.excelcodex.com/2012/06/worksheets-naming-conventions/), they will
         be replaced with `invalid_char_subst`.
         """
 

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -15,7 +15,7 @@ import tablib
 INVALID_TITLE_REGEX = re.compile(r'[\\*?:/\[\]]')
 
 def safe_xlsx_sheet_title(s, replace="-"):
-    return re.sub(INVALID_TITLE_REGEX, s, replace)[:31]
+    return re.sub(INVALID_TITLE_REGEX, replace, s)[:31]
 
 
 class XLSXFormat:
@@ -57,15 +57,23 @@ class XLSXFormat:
         return stream.getvalue()
 
     @classmethod
-    def export_book(cls, databook, freeze_panes=True):
-        """Returns XLSX representation of DataBook."""
+    def export_book(cls, databook, freeze_panes=True, invalid_char_subst="-"):
+        """Returns XLSX representation of DataBook.
+
+        If dataset.title contains characters which are considered invalid for an XLSX file
+        sheet name (http://www.excelcodex.com/2012/06/worksheets-naming-conventions/), it will
+        be replaced with `invalid_char_subst`.
+        """
 
         wb = Workbook()
         for sheet in wb.worksheets:
             wb.remove(sheet)
         for i, dset in enumerate(databook._datasets):
             ws = wb.create_sheet()
-            ws.title = dset.title if dset.title else 'Sheet%s' % (i)
+            ws.title = (
+                safe_xlsx_sheet_title(dset.title, invalid_char_subst)
+                if dset.title else 'Sheet%s' % (i)
+            )
 
             cls.dset_sheet(dset, ws, freeze_panes=freeze_panes)
 

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1045,8 +1045,22 @@ class XLSXTests(BaseTestCase):
         self.assertEqual(new_data.headers, ['id', 'name', 'description'])
 
     def test_xlsx_bad_chars_sheet_name(self):
-        data.title = "this / is / good"
-        _xlsx = data.xlsx
+        """
+        Sheet names are limited to 30 chars and following chars
+        are not permitted: \\ / * ? : [ ]
+        """
+        _dataset = tablib.Dataset(
+            title='bad name \\/*?:[]qwertyuiopasdfghjklzxcvbnm'
+        )
+        _xlsx = _dataset.export('xlsx')
+        new_data = tablib.Dataset().load(_xlsx)
+        self.assertEqual(new_data.title, 'bad name -------qwertyuiopasdfg')
+
+        _book = tablib.Databook()
+        _book.add_sheet(_dataset)
+        _xlsx = _book.export('xlsx')
+        new_data = tablib.Databook().load(_xlsx, 'xlsx')
+        self.assertEqual(new_data.sheets()[0].title, 'bad name -------qwertyuiopasdfg')
 
     def test_xlsx_import_set_ragged(self):
         """Import XLSX file when not all rows have the same length."""

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1046,7 +1046,7 @@ class XLSXTests(BaseTestCase):
 
     def test_xlsx_bad_chars_sheet_name(self):
         """
-        Sheet names are limited to 30 chars and following chars
+        Sheet names are limited to 30 chars and the following chars
         are not permitted: \\ / * ? : [ ]
         """
         _dataset = tablib.Dataset(


### PR DESCRIPTION
PR #490 had non-functional tests and thus an invalid order of arguments to re.sub was unnoticed.
This PR corrects the call, adds tests + applies same treatment to sheet names also when saving a databook.

Fixes #489
Related to #490