### PR TITLE
feat: support column_width in xlsx format

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,3 +34,4 @@ Here is a list of past and present much-appreciated contributors:
     Tsuyoshi Hombashi
     Tushar Makkar
     Yunis Yilmaz
+    Egor Osokin

--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Here is a list of past and present much-appreciated contributors:
     Bruno Soares
     Claude Paroz
     Daniel Santos
+    Egor Osokin
     Erik Youngren
     Hugo van Kemenade
     Iuri de Silvio

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@ by the Jazzband GitHub team.
 Here is a list of past and present much-appreciated contributors:
 
     Alex Gaynor
+    Andrew Graham-Yooll
     Andrii Soldatenko
     Benjamin Wohlwend
     Bruno Soares

--- a/AUTHORS
+++ b/AUTHORS
@@ -35,4 +35,3 @@ Here is a list of past and present much-appreciated contributors:
     Tsuyoshi Hombashi
     Tushar Makkar
     Yunis Yilmaz
-    Egor Osokin

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+## Unreleased
+
+### Improvements
+
+- Add support for exporting XLSX with column width (#516)
+
 ## 3.7.0 (2024-10-08)
 
 ### Improvements

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## Unreleased
+## 3.8.0 (Unreleased)
 
 ### Improvements
 

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -251,9 +251,14 @@ can set to a number of lines that should be skipped before starting to read
 data.
 
 The ``export_set()`` method supports a ``column_width`` parameter. Depending on the
-value you pass, the column width will be set accordingly. It can be either None, int, or "adapt".
-If "adapt" is passed, the column width will be unique for every column and will be 
-calculated based on values' length
+value you pass, the column width will be set accordingly. It can be either None, int, or "adaptive".
+If "adaptive" is passed, the column width will be unique for every column and will be 
+calculated based on values' length. Example of usage
+
+```python3
+data = tablib.Dataset()
+data.export('xlsx', column_width='adaptive')
+```
 
 
 .. versionchanged:: 3.3.0

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -261,7 +261,7 @@ For example::
 
 .. versionchanged:: 3.8.0
     The ``column_width`` parameter for ``export_set()`` was added.
-    
+
 .. versionchanged:: 3.1.0
 
     The ``skip_lines`` parameter for ``import_set()`` was added.

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -251,8 +251,8 @@ can set to a number of lines that should be skipped before starting to read
 data.
 
 The ``export_set()`` method supports a ``column_width`` parameter. Depending on the
-value you pass, the column width will be set accordingly. It can be either ``None``, an integer, or "adaptive".
-If "adaptive" is passed, the column width will be unique for every column and will be 
+value passed, the column width will be set accordingly. It can be either ``None``, an integer, or default "adaptive".
+If "adaptive" is passed, the column width will be unique and will be 
 calculated based on values' length. For example:: 
 
     data = tablib.Dataset()
@@ -260,7 +260,7 @@ calculated based on values' length. For example::
 
 
 
-.. versionchanged:: 3.3.0
+.. versionchanged:: 3.8.0
     The ``column_width`` parameter for ``export_set()`` was added.
     
 .. versionchanged:: 3.1.0

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -250,6 +250,15 @@ The ``import_set()`` method also supports a ``skip_lines`` parameter that you
 can set to a number of lines that should be skipped before starting to read
 data.
 
+The ``export_set()`` method supports a ``column_width`` parameter. Depending on the
+value you pass, the column width will be set accordingly. It can be either None, int, or "adapt".
+If "adapt" is passed, the column width will be unique for every column and will be 
+calculated based on values' length
+
+
+.. versionchanged:: 3.2.0
+    The ``column_width`` parameter for ``export_set()`` was added.
+    
 .. versionchanged:: 3.1.0
 
     The ``skip_lines`` parameter for ``import_set()`` was added.

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -256,7 +256,7 @@ If "adapt" is passed, the column width will be unique for every column and will 
 calculated based on values' length
 
 
-.. versionchanged:: 3.2.0
+.. versionchanged:: 3.3.0
     The ``column_width`` parameter for ``export_set()`` was added.
     
 .. versionchanged:: 3.1.0

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -250,11 +250,11 @@ The ``import_set()`` method also supports a ``skip_lines`` parameter that you
 can set to a number of lines that should be skipped before starting to read
 data.
 
-The ``export_set()`` method supports a ``column_width`` parameter. Depending 
-on the value passed, the column width will be set accordingly. It can be 
-either ``None``, an integer, or default "adaptive". If "adaptive" is passed, 
-the column width will be unique and will be calculated based on values' length. 
-For example:: 
+The ``export_set()`` method supports a ``column_width`` parameter. Depending
+on the value passed, the column width will be set accordingly. It can be
+either ``None``, an integer, or default "adaptive". If "adaptive" is passed,
+the column width will be unique and will be calculated based on values' length.
+For example::
 
     data = tablib.Dataset()
     data.export('xlsx', column_width='adaptive')

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -250,15 +250,14 @@ The ``import_set()`` method also supports a ``skip_lines`` parameter that you
 can set to a number of lines that should be skipped before starting to read
 data.
 
-The ``export_set()`` method supports a ``column_width`` parameter. Depending on the
-value passed, the column width will be set accordingly. It can be either ``None``, an integer, or default "adaptive".
-If "adaptive" is passed, the column width will be unique and will be 
-calculated based on values' length. For example:: 
+The ``export_set()`` method supports a ``column_width`` parameter. Depending 
+on the value passed, the column width will be set accordingly. It can be 
+either ``None``, an integer, or default "adaptive". If "adaptive" is passed, 
+the column width will be unique and will be calculated based on values' length. 
+For example:: 
 
     data = tablib.Dataset()
     data.export('xlsx', column_width='adaptive')
-
-
 
 .. versionchanged:: 3.8.0
     The ``column_width`` parameter for ``export_set()`` was added.

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -251,14 +251,13 @@ can set to a number of lines that should be skipped before starting to read
 data.
 
 The ``export_set()`` method supports a ``column_width`` parameter. Depending on the
-value you pass, the column width will be set accordingly. It can be either None, int, or "adaptive".
+value you pass, the column width will be set accordingly. It can be either ``None``, an integer, or "adaptive".
 If "adaptive" is passed, the column width will be unique for every column and will be 
-calculated based on values' length. Example of usage
+calculated based on values' length. For example:: 
 
-```python3
-data = tablib.Dataset()
-data.export('xlsx', column_width='adaptive')
-```
+    data = tablib.Dataset()
+    data.export('xlsx', column_width='adaptive')
+
 
 
 .. versionchanged:: 3.3.0

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -37,7 +37,7 @@ class XLSXFormat:
             return False
 
     @classmethod
-    def export_set(cls, dataset, freeze_panes=True, invalid_char_subst="-", escape=False):
+    def export_set(cls, dataset, freeze_panes=True, invalid_char_subst="-", escape=False, column_width="adaptive"):
         """Returns XLSX representation of Dataset.
 
         If ``freeze_panes`` is True, Export will freeze panes only after first line.
@@ -173,7 +173,7 @@ class XLSXFormat:
 
                 if escape and cell.data_type == 'f' and cell.value.startswith('='):
                     cell.value = cell.value.replace("=", "")
-                    
+
     @classmethod
     def _adapt_column_width(cls, worksheet,
                             width: Optional[Union[str, int]]) -> None:

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -62,7 +62,7 @@ class XLSXFormat:
         cls.dset_sheet(dataset, ws, freeze_panes=freeze_panes, escape=escape)
         if isinstance(column_width, str) and column_width != "adaptive":
             raise ValueError(f"Unsupported value `{column_width}` passed to `column_width` "
-                             f"parameter. It supports 'adaptive' or integer values")
+                             "parameter. It supports 'adaptive' or integer values")
 
         cls._adapt_column_width(ws, column_width)
 

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -1,7 +1,5 @@
 """ Tablib - XLSX Support.
 """
-from __future__ import annotations
-
 import re
 from io import BytesIO
 

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -191,7 +191,7 @@ class XLSXFormat:
                     else:
                         column_widths += [len(cell)]
         else:
-            column_widths = [width] * len(worksheet.values)
+            column_widths = [width] * worksheet.max_column
         
         for i, column_width in enumerate(column_widths, 1): # start at 1
             worksheet.column_dimensions[get_column_letter(i)].width = column_width

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -1,9 +1,9 @@
 """ Tablib - XLSX Support.
 """
+from __future__ import annotations
 
 import re
 from io import BytesIO
-from typing import Optional, Union
 
 from openpyxl.reader.excel import ExcelReader, load_workbook
 from openpyxl.styles import Alignment, Font
@@ -176,7 +176,7 @@ class XLSXFormat:
 
     @classmethod
     def _adapt_column_width(cls, worksheet,
-                            width: Optional[Union[str, int]]) -> None:
+                            width: str | int | None) -> None:
         if width is None:
             return
 

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -176,8 +176,11 @@ class XLSXFormat:
     @classmethod
     def _adapt_column_width(cls, worksheet, width):
         if isinstance(width, str) and width != "adaptive":
-            raise ValueError(f"Unsupported value `{width}` passed to `column_width` "
-                             "parameter. It supports 'adaptive' or integer values")
+            msg = (
+                f"Invalid value for column_width: {width}. "
+                f"Must be 'adaptive' or an integer."
+            )
+            raise ValueError(msg)
         
         if width is None:
             return

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -180,7 +180,7 @@ class XLSXFormat:
         if isinstance(width, str) and width != "adaptive":
             msg = (
                 f"Invalid value for column_width: {width}. "
-                f"Must be 'adaptive' or an integer."
+                "Must be 'adaptive' or an integer."
             )
             raise ValueError(msg)
 

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -191,12 +191,12 @@ class XLSXFormat:
         if width == "adaptive":
             for row in worksheet.values:
                 for i, cell in enumerate(row):
-                    cell = str(cell)
+                    cell_width = len(str(cell))
                     if len(column_widths) > i:
-                        if len(cell) > column_widths[i]:
-                            column_widths[i] = len(cell)
+                        if cell_width > column_widths[i]:
+                            column_widths[i] = cell_width
                     else:
-                        column_widths.append(len(cell))
+                        column_widths.append(cell_width)
         else:
             column_widths = [width] * worksheet.max_column
 

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -34,7 +34,8 @@ class XLSXFormat:
             return False
 
     @classmethod
-    def export_set(cls, dataset, freeze_panes=True, invalid_char_subst="-", escape=False, column_width="adaptive"):
+    def export_set(cls, dataset, freeze_panes=True, invalid_char_subst="-",
+                   escape=False, column_width="adaptive"):
         """Returns XLSX representation of Dataset.
 
         If ``freeze_panes`` is True, Export will freeze panes only after first line.
@@ -50,7 +51,8 @@ class XLSXFormat:
 
         If ``column_width`` is set to "adaptive", the column width will be set to the maximum
         width of the content in each column. If it is set to an integer, the column width will be
-        set to that integer value. If it is set to None, the column width will be set as the default openpyxl.Worksheet width value.
+        set to that integer value. If it is set to None, the column width will be set as the
+        default openpyxl.Worksheet width value.
 
         """
         wb = Workbook()
@@ -181,7 +183,7 @@ class XLSXFormat:
                 f"Must be 'adaptive' or an integer."
             )
             raise ValueError(msg)
-        
+
         if width is None:
             return
 
@@ -197,6 +199,6 @@ class XLSXFormat:
                         column_widths.append(len(cell))
         else:
             column_widths = [width] * worksheet.max_column
-        
-        for i, column_width in enumerate(column_widths, 1): # start at 1
+
+        for i, column_width in enumerate(column_widths, 1):  # start at 1
             worksheet.column_dimensions[get_column_letter(i)].width = column_width

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1341,6 +1341,24 @@ class XLSTests(BaseTestCase):
 
 
 class XLSXTests(BaseTestCase):
+    def _helper_export_column_width(self, column_width):
+        """check that column width adapts to value length"""
+        def _get_width(data, input_arg):
+            xlsx_content = data.export('xlsx', column_width=input_arg)
+            wb = load_workbook(filename=BytesIO(xlsx_content))
+            ws = wb.active
+            return ws.column_dimensions['A'].width
+
+        xls_source = Path(__file__).parent / 'files' / 'xlsx_cell_values.xlsx'
+        with xls_source.open('rb') as fh:
+            data = tablib.Dataset().load(fh)
+        width_before = _get_width(data, column_width)
+        data.append([
+            'verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue',
+        ])
+        width_after = _get_width(data, width_before)
+        return width_before, width_after
+    
     def test_xlsx_format_detect(self):
         """Test the XLSX format detection."""
         in_stream = self.founders.xlsx
@@ -1484,45 +1502,27 @@ class XLSXTests(BaseTestCase):
         _xlsx = data.export('xlsx')
         wb = load_workbook(filename=BytesIO(_xlsx))
         self.assertEqual('[1]', wb.active['A1'].value)
-        
-    def _helper_export_column_width(self, input_arg):
-        """check that column width adapts to value length"""
-        def _get_width(data, input_arg):
-            xlsx_content = data.export('xlsx', column_width=input_arg)
-            wb = load_workbook(filename=BytesIO(xlsx_content))
-            ws = wb.active
-            return ws.column_dimensions['A'].width
-
-        xls_source = Path(__file__).parent / 'files' / 'xlsx_cell_values.xlsx'
-        with xls_source.open('rb') as fh:
-            data = tablib.Dataset().load(fh)
-        width_before = _get_width(data, input_arg)
-        data.append([
-            'verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue',
-        ])
-        width_after = _get_width(data, width_before)
-        return width_before, width_after
-
-    def test_xlsx_column_width_none(self):
-        """check column width with None"""
-        width_before, width_after = self._helper_export_column_width(None)
-        self.assertEqual(width_before, 13)
-        self.assertEqual(width_after, 13)
-
+    
     def test_xlsx_column_width_adaptive(self):
-        """check column width with 'adaptive'"""
+        """ Test that column width adapts to value length"""
         width_before, width_after = self._helper_export_column_width("adaptive")
         self.assertEqual(width_before, 11)
         self.assertEqual(width_after, 11)
 
     def test_xlsx_column_width_integer(self):
-        """check column width with an integer"""
+        """Test that column width changes to integer length"""
         width_before, width_after = self._helper_export_column_width(10)
         self.assertEqual(width_before, 10)
         self.assertEqual(width_after, 10)
+    
+    def test_xlsx_column_width_none(self):
+        """Test that column width does not change"""
+        width_before, width_after = self._helper_export_column_width(None)
+        self.assertEqual(width_before, 13)
+        self.assertEqual(width_after, 13)
 
     def test_xlsx_column_width_value_error(self):
-        """check column width with invalid input"""
+        """Raise ValueError if column_width is not a valid input"""
         with self.assertRaises(ValueError):
             self._helper_export_column_width("invalid input")
 

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1501,8 +1501,8 @@ class XLSXTests(BaseTestCase):
             'verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue',
         ])
         width_after = _get_width(data)
-      
-        assert width_before != width_after    
+        
+        self.assertNotEqual(width_before, width_after)
         
 class JSONTests(BaseTestCase):
     def test_json_format_detect(self):

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -11,13 +11,11 @@ import unittest
 from decimal import Decimal
 from io import BytesIO, StringIO
 from pathlib import Path
-from tempfile import TemporaryFile
 from uuid import uuid4
 
 import xlrd
 from odf import opendocument, table
 from openpyxl.reader.excel import load_workbook
-from MarkupPy import markup
 
 import tablib
 from tablib.core import Row, detect_format
@@ -1354,11 +1352,12 @@ class XLSXTests(BaseTestCase):
             data = tablib.Dataset().load(fh)
         width_before = _get_width(data, column_width)
         data.append([
-            'verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue',
+            'verylongvalue-verylongvalue-verylongvalue-verylongvalue-'
+            'verylongvalue-verylongvalue-verylongvalue-verylongvalue',
         ])
         width_after = _get_width(data, width_before)
         return width_before, width_after
-    
+
     def test_xlsx_format_detect(self):
         """Test the XLSX format detection."""
         in_stream = self.founders.xlsx
@@ -1502,7 +1501,7 @@ class XLSXTests(BaseTestCase):
         _xlsx = data.export('xlsx')
         wb = load_workbook(filename=BytesIO(_xlsx))
         self.assertEqual('[1]', wb.active['A1'].value)
-    
+
     def test_xlsx_column_width_adaptive(self):
         """ Test that column width adapts to value length"""
         width_before, width_after = self._helper_export_column_width("adaptive")
@@ -1514,7 +1513,7 @@ class XLSXTests(BaseTestCase):
         width_before, width_after = self._helper_export_column_width(10)
         self.assertEqual(width_before, 10)
         self.assertEqual(width_after, 10)
-    
+
     def test_xlsx_column_width_none(self):
         """Test that column width does not change"""
         width_before, width_after = self._helper_export_column_width(None)

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1485,10 +1485,30 @@ class XLSXTests(BaseTestCase):
         wb = load_workbook(filename=BytesIO(_xlsx))
         self.assertEqual('[1]', wb.active['A1'].value)
 
-    def test_xlsx_column_width(self):
+    def test_xlsx_column_width_none(self):
+        """check that column width adapts to value length"""
+
+        def _get_width(data):
+            xlsx_content = data.export('xlsx', column_width=None)
+            wb = load_workbook(filename=BytesIO(xlsx_content))
+            ws = wb.active
+            return ws.column_dimensions['A'].width
+
+        xls_source = Path(__file__).parent / 'files' / 'xlsx_cell_values.xlsx'
+        with xls_source.open('rb') as fh:
+            data = tablib.Dataset().load(fh)
+        width_before = _get_width(data)
+        data.append([
+            'verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue',
+        ])
+        width_after = _get_width(data)
+
+        self.assertEqual(width_before, width_after)
+        
+    def test_xlsx_column_width_adaptive(self):
         """check that column width adapts to value length"""
         def _get_width(data):
-            xlsx_content = data.export('xlsx')
+            xlsx_content = data.export('xlsx', column_width='adaptive')
             wb = load_workbook(filename=BytesIO(xlsx_content))
             ws = wb.active
             return ws.column_dimensions['A'].width
@@ -1503,7 +1523,30 @@ class XLSXTests(BaseTestCase):
         width_after = _get_width(data)
         
         self.assertNotEqual(width_before, width_after)
+
+    def test_xlsx_column_width_integer(self):
+        """check that column width adapts to value length"""
+        _some_integer = 10
         
+        def _get_width(data):
+            xlsx_content = data.export('xlsx', column_width=_some_integer)
+            wb = load_workbook(filename=BytesIO(xlsx_content))
+            ws = wb.active
+            return ws.column_dimensions['A'].width
+
+        xls_source = Path(__file__).parent / 'files' / 'xlsx_cell_values.xlsx'
+        with xls_source.open('rb') as fh:
+            data = tablib.Dataset().load(fh)
+        width_before = _get_width(data)
+        data.append([
+            'verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue-verylongvalue',
+        ])
+        width_after = _get_width(data)
+
+        self.assertEqual(_some_integer, width_before)
+        self.assertEqual(_some_integer, width_after)
+
+
 class JSONTests(BaseTestCase):
     def test_json_format_detect(self):
         """Test JSON format detection."""


### PR DESCRIPTION
This PR allows user to specify column width in XLXS format. For it has a default value, which is not suitable for long values in dataset. As a result, it is not convenient to look these tables. Also, it eliminates questions like #318 in future

I didn't find tests for exporting, so omitted this. Let me know if they are required