### PR TITLE
Add newline to StringIO

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Here is a list of passed and present much-appreciated contributors:
     Mark Rogers
     Mark Walling
     Mathias Loesch
+    Matthew Hegarty
     Mike Waldner
     Peyman Salehi
     Rabin Nankhwa

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+## 3.2.1 (unreleased)
+
+### Bugfixes
+
+- Support solo CR in text input imports (#518).
+
 ## 3.2.0 (2022-01-27)
 
 ### Changes

--- a/src/tablib/utils.py
+++ b/src/tablib/utils.py
@@ -7,7 +7,7 @@ def normalize_input(stream):
     file-like object.
     """
     if isinstance(stream, str):
-        return StringIO(stream)
+        return StringIO(stream, newline='')
     elif isinstance(stream, bytes):
         return BytesIO(stream)
     return stream

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -824,6 +824,14 @@ class CSVTests(BaseTestCase):
         dataset = tablib.import_set(csv_text, format="csv", skip_lines=2)
         self.assertEqual(dataset.headers, ['id', 'name','description'])
 
+    def test_csv_import_mac_os_lf(self):
+        csv_text = (
+            'id,name,description\r'
+            '12,Smith,rounded\r'
+        )
+        dataset = tablib.import_set(csv_text, format="csv")
+        self.assertEqual('id,name,description\r\n12,Smith,rounded\r\n', dataset.csv)
+
     def test_csv_export(self):
         """Verify exporting dataset object as CSV."""
 


### PR DESCRIPTION
This is a fix for #517.
Adding the [newline](https://docs.python.org/3/glossary.html#term-universal-newlines) kwarg to `StringIO` handles interpreting the LF char.

https://docs.python.org/3/library/functions.html#open-newline-parameter