### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
           cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
           cache: pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -36,6 +36,6 @@ jobs:
         tox -e py
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     python_requires='>=3.7',
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ minversion = 2.4
 envlist =
     docs
     lint
-    py{37,38,39,310}
+    py{37,38,39,310,311}
 
 [testenv]
 deps =


### PR DESCRIPTION
[Python 3.11.0 final](https://peps.python.org/pep-0664/) is set for release on 2022-10-24, we can already test and set the Trove classifier.

Also bump GitHub Actions versions.