### PR TITLE
Fix deploy warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    if: github.repository == 'jazzband/tablib'
+    if: github.repository_owner == 'jazzband'
     runs-on: ubuntu-latest
 
     steps:
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.x"
           cache: pip
           cache-dependency-path: "setup.py"
 
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload packages to Jazzband
         if: github.event.action == 'published'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: jazzband
           password: ${{ secrets.JAZZBAND_RELEASE_KEY }}


### PR DESCRIPTION
The deploy workflow shows this warning:

> [build: # >> PyPA publish to PyPI GHA: UNSUPPORTED GITHUB ACTION VERSION <<#L1](https://github.com/jazzband/tablib/commit/4719f97081f67e73b0daa5f8b89dafff85306a10#annotation_6935852056)
 You are using "pypa/gh-action-pypi-publish@master". The "master" branch of this project has been sunset and will not receive any updates, not even security bug fixes. Please, make sure to use a supported version. If you want to pin to v1 major version, use "pypa/gh-action-pypi-publish@release/v1". If you feel adventurous, you may opt to use use "pypa/gh-action-pypi-publish@unstable/v1" instead. A more general recommendation is to pin to exact tags or commit shas.

https://github.com/jazzband/tablib/actions/runs/3664520628

So let's use v1.

---

Also we can make the `github.repository == 'jazzband/tablib'` check more generic as `github.repository_owner == 'jazzband'`, so we can have fewer changes between Jazzband repos.

And similarly, use Python version `3.x` for the latest available, instead of pinning to a specific. 
