### PR TITLE
Fix spelling of word in AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
 Tablib was originally written by Kenneth Reitz and is now maintained
 by the Jazzband GitHub team.
 
-Here is a list of passed and present much-appreciated contributors:
+Here is a list of past and present much-appreciated contributors:
 
     Alex Gaynor
     Andrii Soldatenko


### PR DESCRIPTION
This updates the spelling / meaning of a word in the `AUTHORS` file. Feel free to close this pull request if it was spelled as "passed" for a reason.