### PR TITLE
Fix linting issues raised by flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args: [--py37-plus]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,16 @@ setup(
     ],
     python_requires='>=3.7',
     extras_require={
-        'all': ['markuppy', 'odfpy', 'openpyxl>=2.6.0', 'pandas', 'pyyaml', 'tabulate', 'xlrd', 'xlwt'],
+        'all': [
+            'markuppy',
+            'odfpy',
+            'openpyxl>=2.6.0',
+            'pandas',
+            'pyyaml',
+            'tabulate',
+            'xlrd',
+            'xlwt',
+        ],
         'cli': ['tabulate'],
         'html': ['markuppy'],
         'ods': ['odfpy'],

--- a/src/tablib/core.py
+++ b/src/tablib/core.py
@@ -333,11 +333,14 @@ class Dataset:
             data.dict = [{'age': 90, 'first_name': 'Kenneth', 'last_name': 'Reitz'}]
 
         """
-        error_details = "Please check format documentation https://tablib.readthedocs.io/en/stable/formats.html#yaml"
+        error_details = (
+            "Please check format documentation "
+            "https://tablib.readthedocs.io/en/stable/formats.html#yaml"
+        )
 
         if not pickle:
             return
-        
+
         if not isinstance(pickle, list):
             # sometimes pickle is a dict and len(pickle) returns True.
             # since we access index 0 we should check if the type is list
@@ -764,7 +767,9 @@ class Dataset:
         """Removes all duplicate rows from the :class:`Dataset` object
         while maintaining the original order."""
         seen = set()
-        self._data[:] = [row for row in self._data if not (tuple(row) in seen or seen.add(tuple(row)))]
+        self._data[:] = [
+            row for row in self._data if not (tuple(row) in seen or seen.add(tuple(row)))
+        ]
 
     def wipe(self):
         """Removes all content and headers from the :class:`Dataset` object."""

--- a/src/tablib/formats/_dbf.py
+++ b/src/tablib/formats/_dbf.py
@@ -60,7 +60,7 @@ class DBFFormat:
     def detect(cls, stream):
         """Returns True if the given stream is valid DBF"""
         try:
-            _dbf = dbf.Dbf(stream, readOnly=True)
+            dbf.Dbf(stream, readOnly=True)
             return True
         except Exception:
             return False

--- a/src/tablib/formats/_latex.py
+++ b/src/tablib/formats/_latex.py
@@ -55,7 +55,7 @@ class LATEXFormat:
         midrule = cls._midrule(dataset.width)
         body = '\n'.join([cls._serialize_row(row) for row in dataset])
         return cls.TABLE_TEMPLATE % dict(CAPTION=caption, COLSPEC=colspec,
-                                     HEADER=header, MIDRULE=midrule, BODY=body)
+                                         HEADER=header, MIDRULE=midrule, BODY=body)
 
     @classmethod
     def _colspec(cls, dataset_width):

--- a/src/tablib/formats/_ods.py
+++ b/src/tablib/formats/_ods.py
@@ -7,7 +7,11 @@ from io import BytesIO
 from odf import opendocument, style, table, text
 
 bold = style.Style(name="bold", family="paragraph")
-bold.addElement(style.TextProperties(fontweight="bold", fontweightasian="bold", fontweightcomplex="bold"))
+bold.addElement(style.TextProperties(
+    fontweight="bold",
+    fontweightasian="bold",
+    fontweightcomplex="bold",
+))
 
 
 class ODSFormat:

--- a/src/tablib/formats/_rst.py
+++ b/src/tablib/formats/_rst.py
@@ -62,12 +62,14 @@ class ReSTFormat:
             raise ValueError('Value of "justify" must be one of "{}"'.format(
                 '", "'.join(JUSTIFY_VALUES)
             ))
-        if justify == JUSTIFY_LEFT:
-            just = lambda text, width: text.ljust(width)
-        elif justify == JUSTIFY_CENTER:
-            just = lambda text, width: text.center(width)
-        else:
-            just = lambda text, width: text.rjust(width)
+
+        def just(text_, width_):
+            if justify == JUSTIFY_LEFT:
+                return text_.ljust(width_)
+            elif justify == JUSTIFY_CENTER:
+                return text_.center(width_)
+            else:
+                return text_.rjust(width_)
         lpad = sep + ' ' if sep else ''
         rpad = ' ' + sep if sep else ''
         pad = ' ' + sep + ' '
@@ -95,9 +97,9 @@ class ReSTFormat:
         median_lens = [int(median(lens)) for lens in str_lens]
         total = sum(median_lens)
         if total > max_table_width - (pad_len * len(median_lens)):
-            column_widths = (max_table_width * l // total for l in median_lens)
+            column_widths = (max_table_width * lens // total for lens in median_lens)
         else:
-            column_widths = (l for l in median_lens)
+            column_widths = (lens for lens in median_lens)
         # Allow for separator and padding:
         column_widths = (w - pad_len if w > pad_len else w for w in column_widths)
         # Rather widen table than break words:

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -8,11 +8,11 @@ from openpyxl.reader.excel import ExcelReader, load_workbook
 from openpyxl.styles import Alignment, Font
 from openpyxl.utils import get_column_letter
 from openpyxl.workbook import Workbook
-from openpyxl.writer.excel import ExcelWriter
 
 import tablib
 
 INVALID_TITLE_REGEX = re.compile(r'[\\*?:/\[\]]')
+
 
 def safe_xlsx_sheet_title(s, replace="-"):
     return re.sub(INVALID_TITLE_REGEX, replace, s)[:31]

--- a/src/tablib/packages/dbfpy/dbf.py
+++ b/src/tablib/packages/dbfpy/dbf.py
@@ -1,4 +1,13 @@
 #! /usr/bin/env python
+
+from . import header, record
+from .utils import INVALID_VALUE
+
+__version__ = "$Revision: 1.7 $"[11:-2]
+__date__ = "$Date: 2007/02/11 09:23:13 $"[7:-2]
+__author__ = "Jeff Kunce <kuncej@mail.conservation.state.mo.us>"
+__all__ = ["Dbf"]
+
 """DBF accessing helpers.
 
 FIXME: more documentation needed
@@ -55,15 +64,6 @@ Examples:
 19-feb-1998 [jjk]   add create/write capabilities
 18-feb-1998 [jjk]   from dbfload.py
 """
-
-__version__ = "$Revision: 1.7 $"[11:-2]
-__date__ = "$Date: 2007/02/11 09:23:13 $"[7:-2]
-__author__ = "Jeff Kunce <kuncej@mail.conservation.state.mo.us>"
-
-__all__ = ["Dbf"]
-
-from . import header, record
-from .utils import INVALID_VALUE
 
 
 class Dbf:
@@ -293,5 +293,3 @@ if __name__ == '__main__':
     _name = len(sys.argv) > 1 and sys.argv[1] or "county.dbf"
     demo_create(_name)
     demo_read(_name)
-
-# vim: set et sw=4 sts=4 :

--- a/src/tablib/packages/dbfpy/dbfnew.py
+++ b/src/tablib/packages/dbfpy/dbfnew.py
@@ -1,4 +1,21 @@
 #!/usr/bin/python
+
+__version__ = "$Revision: 1.4 $"[11:-2]
+__date__ = "$Date: 2006/07/04 08:18:18 $"[7:-2]
+
+__all__ = ["dbf_new"]
+
+from .dbf import Dbf
+from .fields import (
+    DbfCharacterFieldDef,
+    DbfDateFieldDef,
+    DbfDateTimeFieldDef,
+    DbfLogicalFieldDef,
+    DbfNumericFieldDef,
+)
+from .header import DbfHeader
+from .record import DbfRecord
+
 """.DBF creation helpers.
 
 Note: this is a legacy interface.  New code should use Dbf class
@@ -18,16 +35,6 @@ TODO:
                     dbf_new now is a new class (inherited from object)
 ??-jun-2000 [--]    added by Hans Fiby
 """
-
-__version__ = "$Revision: 1.4 $"[11:-2]
-__date__ = "$Date: 2006/07/04 08:18:18 $"[7:-2]
-
-__all__ = ["dbf_new"]
-
-from .dbf import *
-from .fields import *
-from .header import *
-from .record import *
 
 
 class _FieldDefinition:
@@ -179,5 +186,3 @@ if __name__ == '__main__':
             print(f'{fldName}:\t {rec[fldName]}')
         print()
     dbft.close()
-
-# vim: set et sts=4 sw=4 :

--- a/src/tablib/packages/dbfpy/fields.py
+++ b/src/tablib/packages/dbfpy/fields.py
@@ -1,3 +1,15 @@
+import datetime
+import struct
+from functools import total_ordering
+
+from . import utils
+
+__version__ = "$Revision: 1.14 $"[11:-2]
+__date__ = "$Date: 2009/05/26 05:16:51 $"[7:-2]
+
+__all__ = ["lookupFor"]  # field classes added at the end of the module
+
+
 """DBF fields definitions.
 
 TODO:
@@ -24,18 +36,6 @@ TODO:
 20-dec-2005 [yc]    use field names in upper case
 15-dec-2005 [yc]    field definitions moved from `dbf`.
 """
-
-__version__ = "$Revision: 1.14 $"[11:-2]
-__date__ = "$Date: 2009/05/26 05:16:51 $"[7:-2]
-
-__all__ = ["lookupFor"]  # field classes added at the end of the module
-
-import datetime
-import struct
-import sys
-from functools import total_ordering
-
-from . import utils
 
 # abstract definitions
 
@@ -131,7 +131,7 @@ class DbfFieldDef:
         assert len(string) == 32
         _length = string[16]
         return cls(utils.unzfill(string)[:11].decode('utf-8'), _length,
-            string[17], start, start + _length, ignoreErrors=ignoreErrors)
+                   string[17], start, start + _length, ignoreErrors=ignoreErrors)
     fromString = classmethod(fromString)
 
     def toString(self):
@@ -256,8 +256,9 @@ class DbfNumericFieldDef(DbfFieldDef):
             if 0 <= _ppos <= self.length:
                 _rv = _rv[:self.length]
             else:
-                raise ValueError("[%s] Numeric overflow: %s (field width: %i)"
-                    % (self.name, _rv, self.length))
+                raise ValueError(
+                    f"[{self.name}] Numeric overflow: {_rv} (field width: {self.length})"
+                )
         return _rv
 
 
@@ -421,7 +422,7 @@ class DbfDateTimeFieldDef(DbfFieldDef):
             value = utils.getDateTime(value)
             # LE byteorder
             _rv = struct.pack("<2I", value.toordinal() + self.JDN_GDN_DIFF,
-                (value.hour * 3600 + value.minute * 60 + value.second) * 1000)
+                              (value.hour * 3600 + value.minute * 60 + value.second) * 1000)
         else:
             _rv = "\0" * self.length
         assert len(_rv) == self.length
@@ -471,5 +472,3 @@ for (_name, _val) in list(globals().items()):
         __all__.append(_name)
         registerField(_val)
 del _name, _val
-
-# vim: et sts=4 sw=4 :

--- a/src/tablib/packages/dbfpy/header.py
+++ b/src/tablib/packages/dbfpy/header.py
@@ -1,3 +1,17 @@
+import datetime
+import io
+import struct
+import sys
+
+from . import fields
+from .utils import getDate
+
+__version__ = "$Revision: 1.6 $"[11:-2]
+__date__ = "$Date: 2010/09/16 05:06:39 $"[7:-2]
+
+__all__ = ["DbfHeader"]
+
+
 """DBF header definition.
 
 TODO:
@@ -13,19 +27,6 @@ TODO:
 04-jul-2006 [als]   added export declaration
 15-dec-2005 [yc]    created
 """
-
-__version__ = "$Revision: 1.6 $"[11:-2]
-__date__ = "$Date: 2010/09/16 05:06:39 $"[7:-2]
-
-__all__ = ["DbfHeader"]
-
-import datetime
-import io
-import struct
-import sys
-
-from . import fields
-from .utils import getDate
 
 
 class DbfHeader:
@@ -164,8 +165,9 @@ Version (signature): 0x%02x
       Record length: %d
        Record count: %d
  FieldName Type Len Dec
-""" % (self.signature, self.lastUpdate, self.headerLength,
-    self.recordLength, self.recordCount)
+"""
+        _rv = _rv % (self.signature, self.lastUpdate, self.headerLength,
+                     self.recordLength, self.recordCount)
         _rv += "\n".join(
             ["%10s %4s %3s %3s" % _fld.fieldInfo() for _fld in self.fields]
         )
@@ -241,13 +243,13 @@ Version (signature): 0x%02x
     def toString(self):
         """Returned 32 chars length string with encoded header."""
         return struct.pack("<4BI2H",
-            self.signature,
-            self.year - 1900,
-            self.month,
-            self.day,
-            self.recordCount,
-            self.headerLength,
-            self.recordLength) + (b'\x00' * 20)
+                           self.signature,
+                           self.year - 1900,
+                           self.month,
+                           self.day,
+                           self.recordCount,
+                           self.headerLength,
+                           self.recordLength) + (b'\x00' * 20)
         # TODO: figure out if bytes(utf-8) is correct here.
 
     def setCurrentDate(self):

--- a/src/tablib/packages/dbfpy/record.py
+++ b/src/tablib/packages/dbfpy/record.py
@@ -1,3 +1,13 @@
+import sys
+
+from . import utils
+
+__version__ = "$Revision: 1.7 $"[11:-2]
+__date__ = "$Date: 2007/02/11 09:05:49 $"[7:-2]
+
+__all__ = ["DbfRecord"]
+
+
 """DBF record definition.
 
 """
@@ -10,15 +20,6 @@
                     added delete() method.
 16-dec-2005 [yc]    record definition moved from `dbf`.
 """
-
-__version__ = "$Revision: 1.7 $"[11:-2]
-__date__ = "$Date: 2007/02/11 09:05:49 $"[7:-2]
-
-__all__ = ["DbfRecord"]
-
-import sys
-
-from . import utils
 
 
 class DbfRecord:
@@ -82,7 +83,7 @@ class DbfRecord:
             self.fieldData = list(data)
 
     # XXX: validate self.index before calculating position?
-    position = property(lambda self: self.dbf.header.headerLength + \
+    position = property(lambda self: self.dbf.header.headerLength +
                         self.index * self.dbf.header.recordLength)
 
     def rawFromStream(cls, dbf, index):
@@ -101,9 +102,9 @@ class DbfRecord:
         # XXX: may be write smth assuming, that current stream
         # position is the required one? it could save some
         # time required to calculate where to seek in the file
-        dbf.stream.seek(dbf.header.headerLength +
-            index * dbf.header.recordLength)
+        dbf.stream.seek(dbf.header.headerLength + index * dbf.header.recordLength)
         return dbf.stream.read(dbf.header.recordLength)
+
     rawFromStream = classmethod(rawFromStream)
 
     def fromStream(cls, dbf, index):
@@ -120,6 +121,7 @@ class DbfRecord:
 
         """
         return cls.fromString(dbf, cls.rawFromStream(dbf, index), index)
+
     fromStream = classmethod(fromStream)
 
     def fromString(cls, dbf, string, index=None):
@@ -137,21 +139,20 @@ class DbfRecord:
         Return value is an instance of the current class.
 
         """
-        return cls(dbf, index, string[0]=="*",
+        return cls(dbf, index, string[0] == "*",
                    [_fd.decodeFromRecord(string) for _fd in dbf.header.fields])
+
     fromString = classmethod(fromString)
 
     # object representation
 
     def __repr__(self):
-        _template = "%%%ds: %%s (%%s)" % max(len(_fld)
-            for _fld in self.dbf.fieldNames)
+        _template = "%%%ds: %%s (%%s)" % max(len(_fld) for _fld in self.dbf.fieldNames)
         _rv = []
         for _fld in self.dbf.fieldNames:
             _val = self[_fld]
             if _val is utils.INVALID_VALUE:
-                _rv.append(_template %
-                    (_fld, "None", "value cannot be decoded"))
+                _rv.append(_template % (_fld, "None", "value cannot be decoded"))
             else:
                 _rv.append(_template % (_fld, _val, type(_val)))
         return "\n".join(_rv)
@@ -166,7 +167,6 @@ class DbfRecord:
             use 'store' instead publicly.
             Be design ``_write`` method should be called
             only from the `Dbf` instance.
-
 
         """
         self._validateIndex(False)
@@ -220,12 +220,8 @@ class DbfRecord:
 
     def toString(self):
         """Return string packed record values."""
-#        for (_def, _dat) in zip(self.dbf.header.fields, self.fieldData):
-#
-
         return "".join([" *"[self.deleted]] + [
-           _def.encodeValue(_dat)
-            for (_def, _dat) in zip(self.dbf.header.fields, self.fieldData)
+           _def.encodeValue(_dat) for (_def, _dat) in zip(self.dbf.header.fields, self.fieldData)
         ])
 
     def asList(self):
@@ -263,5 +259,3 @@ class DbfRecord:
             return self.fieldData[key]
         # assuming string field name
         self.fieldData[self.dbf.indexOfFieldName(key)] = value
-
-# vim: et sts=4 sw=4 :

--- a/src/tablib/packages/dbfpy/utils.py
+++ b/src/tablib/packages/dbfpy/utils.py
@@ -1,3 +1,10 @@
+import datetime
+import time
+
+__version__ = "$Revision: 1.4 $"[11:-2]
+__date__ = "$Date: 2007/02/11 08:57:17 $"[7:-2]
+
+
 """String utilities.
 
 TODO:
@@ -9,12 +16,6 @@ TODO:
 20-dec-2005 [yc]    handle long objects in getDate/getDateTime
 16-dec-2005 [yc]    created from ``strutil`` module.
 """
-
-__version__ = "$Revision: 1.4 $"[11:-2]
-__date__ = "$Date: 2007/02/11 08:57:17 $"[7:-2]
-
-import datetime
-import time
 
 
 def unzfill(str):

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -303,7 +303,10 @@ class TablibTestCase(BaseTestCase):
             tablib.Databook().load('Any stream', 'csv')
 
     def test_book_unsupported_export(self):
-        book = tablib.Databook().load('[{"title": "first", "data": [{"first_name": "John"}]}]', 'json')
+        book = tablib.Databook().load(
+            '[{"title": "first", "data": [{"first_name": "John"}]}]',
+            'json',
+        )
         with self.assertRaises(UnsupportedFormat):
             book.export('csv')
 
@@ -353,7 +356,8 @@ class TablibTestCase(BaseTestCase):
         self.assertEqual(tablib.detect_format(_tsv), 'tsv')
 
         _bunk = StringIO(
-            '¡¡¡¡¡¡---///\n\n\n¡¡£™∞¢£§∞§¶•¶ª∞¶•ªº••ª–º§•†•§º¶•†¥ª–º•§ƒø¥¨©πƒø†ˆ¥ç©¨√øˆ¥≈†ƒ¥ç©ø¨çˆ¥ƒçø¶'
+            '¡¡¡¡¡¡---///\n\n\n' +
+            '¡¡£™∞¢£§∞§¶•¶ª∞¶•ªº••ª–º§•†•§º¶•†¥ª–º•§ƒø¥¨©πƒø†ˆ¥ç©¨√øˆ¥≈†ƒ¥ç©ø¨çˆ¥ƒçø¶'
         )
         self.assertEqual(tablib.detect_format(_bunk), None)
 
@@ -829,7 +833,7 @@ class CSVTests(BaseTestCase):
             '12,Smith,rounded\n'
         )
         dataset = tablib.import_set(csv_text, format="csv", skip_lines=2)
-        self.assertEqual(dataset.headers, ['id', 'name','description'])
+        self.assertEqual(dataset.headers, ['id', 'name', 'description'])
 
     def test_csv_import_mac_os_lf(self):
         csv_text = (

--- a/tests/test_tablib_dbfpy_packages_utils.py
+++ b/tests/test_tablib_dbfpy_packages_utils.py
@@ -151,7 +151,7 @@ class UtilsGetDateTimeTestCase(unittest.TestCase):
 
         # Act / Assert
         with self.assertRaises(NotImplementedError):
-            output = utils.getDateTime(value)
+            utils.getDateTime(value)
 
 
 class InvalidValueTestCase(unittest.TestCase):


### PR DESCRIPTION
I ran flake8 and fixed all issues raised by it.
In my next PR, I will add flake8 to pre-commit (I can't send that PR before this because pre-commit runs by tox and breaks CI)

The change in `isort` version is because of a bug that fixed in the latest release. [link](https://github.com/PyCQA/isort/releases/tag/5.12.0) - [issue link](https://github.com/PyCQA/isort/pull/2078)