### PR TITLE
Add <tbody> tags to html output

### DIFF
--- a/src/tablib/formats/_html.py
+++ b/src/tablib/formats/_html.py
@@ -30,11 +30,13 @@ class HTMLFormat:
             page.tr(headers)
             page.thead.close()
 
+        page.tbody.open()
         for row in dataset:
             new_row = [item if item is not None else '' for item in row]
 
             html_row = markup.oneliner.td(new_row)
             page.tr(html_row)
+        page.tbody.close()
 
         page.table.close()
 

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -623,8 +623,10 @@ class HTMLTests(BaseTestCase):
         html.tr(markup.oneliner.th(self.founders.headers))
         html.thead.close()
 
+        html.tbody.open()
         for founder in self.founders:
             html.tr(markup.oneliner.td(founder))
+        html.tbody.close()
 
         html.table.close()
         html = str(html)

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -641,7 +641,9 @@ class HTMLTests(BaseTestCase):
         html.tr(markup.oneliner.th(['foo', '', 'bar']))
         html.thead.close()
 
+        html.tbody.open()
         html.tr(markup.oneliner.td(['foo', '', 'bar']))
+        html.tbody.close()
 
         html.table.close()
         html = str(html)


### PR DESCRIPTION
Resolves jazzband/tablib#538

Wrap data rows in `<tbody>` tags to fix minifying (with a header row) when dropping optional end tags.
Otherwise the entire table renders with `<thead>` styling.