### PR TITLE
Release: replace deprecated `repository_url` with `repository-url`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,4 @@ jobs:
         with:
           user: jazzband
           password: ${{ secrets.JAZZBAND_RELEASE_KEY }}
-          repository_url: https://jazzband.co/projects/tablib/upload
+          repository-url: https://jazzband.co/projects/tablib/upload


### PR DESCRIPTION
There's a deprecation warning in the release workflow:

> Input 'repository_url' has been deprecated with message: The inputs have been normalized to use kebab-case. Use `repository-url` instead.

* https://github.com/jazzband/tablib/actions/runs/4510971989

More info:

* https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.7.0