### PR TITLE
Test Python 3.12 beta

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         cache: pip
         cache-dependency-path: "pyproject.toml"
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,6 @@ pytest-cov
 MarkupPy
 odfpy
 openpyxl>=2.6.0
-pandas
 pyyaml
 tabulate
 xlrd

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -13,6 +13,7 @@ from io import BytesIO, StringIO
 from pathlib import Path
 from uuid import uuid4
 
+import pytest
 from MarkupPy import markup
 from openpyxl.reader.excel import load_workbook
 
@@ -20,6 +21,11 @@ import tablib
 from tablib.core import Row, detect_format
 from tablib.exceptions import UnsupportedFormat
 from tablib.formats import registry
+
+try:
+    import pandas
+except ImportError:  # pragma: no cover
+    pandas = None
 
 
 class BaseTestCase(unittest.TestCase):
@@ -264,6 +270,7 @@ class TablibTestCase(BaseTestCase):
             'c|3'
         ])
 
+    @pytest.mark.skipif(pandas is None, reason="pandas is not installed")
     def test_unicode_append(self):
         """Passes in a single unicode character and exports."""
 
@@ -272,6 +279,7 @@ class TablibTestCase(BaseTestCase):
         data.append(new_row)
         self._test_export_data_in_all_formats(data)
 
+    @pytest.mark.skipif(pandas is None, reason="pandas is not installed")
     def test_datetime_append(self):
         """Passes in a single datetime and a single date and exports."""
 
@@ -283,6 +291,7 @@ class TablibTestCase(BaseTestCase):
         data.append(new_row)
         self._test_export_data_in_all_formats(data)
 
+    @pytest.mark.skipif(pandas is None, reason="pandas is not installed")
     def test_separator_append(self):
         for a in range(3):
             data.append_separator('foobar')
@@ -328,6 +337,7 @@ class TablibTestCase(BaseTestCase):
         dset = tablib.Dataset().load(tmp_file, 'yaml')
         self.assertEqual(dset.json, '[]')
 
+    @pytest.mark.skipif(pandas is None, reason="pandas is not installed")
     def test_auto_format_detect(self):
         """Test auto format detection."""
         # html, jira, latex, rst are export only.

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,13 @@ minversion = 2.4
 envlist =
     docs
     lint
-    py{37,38,39,310,311}
+    py{37,38,39,310,311,312}
 
 [testenv]
 deps =
     -rtests/requirements.txt
-extras = pandas
+commands_pre =
+    - {envpython} -m pip install --only-binary :all: pandas
 passenv =
     FORCE_COLOR
 commands =


### PR DESCRIPTION
The [Python 3.12 beta](https://discuss.python.org/t/python-3-12-beta-1-and-feature-freeze-is-here/26982?u=hugovk) is now out, let's start testing it: https://dev.to/hugovk/help-test-python-312-beta-1508/

Because pandas doesn't yet support 3.12, we need to skip the pandas-related tests for now. We can do that with `pip install --only-binary :all: pandas`, which only installs pandas if there's a prebuilt binary wheel available (as it is for 3.7-3.11), and skip when it's not available.

I didn't add the 3.12 Trove classifier yet. We could wait until full release in October, but some other projects have added it already:

* 7 in the top 360: https://pyreadiness.org/3.12/
* 1,083 in total: https://pypi.org/search/?c=Programming+Language+%3A%3A+Python+%3A%3A+3.12

Shall we wait or add it now?