### PR TITLE
Drop support for EOL Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
     {name = "Hugo van Kemenade"},
     {name = "Claude Paroz", email = "claude@2xlibre.net"},
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -24,7 +24,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Python 3.7 is EOL this month:

<img width="751" alt="image" src="https://github.com/ultrajson/ultrajson/assets/1324225/7f2736b1-3aef-48f6-b863-4787c754147d">

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0537/

Let's drop it. I don't mind if we wait until 2023-06-27, but we're probably close enough?

---

Does dropping a Python warrant a major or minor bump?

I used to do major, but `python_requires = >=3.8` ensures the new release only installs for the right group, and I'm now leaning towards a minor, but either is fine with me.

(If we had deprecations to drop, I'd do those at the same time and do major, but we don't.)

A [recent poll](https://hachyderm.io/@nedbat/110412912217669532) on the topic favours minor:

<img width="560" alt="image" src="https://github.com/ultrajson/ultrajson/assets/1324225/2c141003-9a0b-4738-812f-216f8aad5668">

