### PR TITLE
refactored html export to allow for optional escaping

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - The html format now supports importing from HTML content (#243)
+- Refactored html export to allow optional escaping of characters (#)
 
 ### Changes
 

--- a/src/tablib/formats/_html.py
+++ b/src/tablib/formats/_html.py
@@ -15,24 +15,24 @@ class HTMLFormat:
         """Returns HTML representation of Dataset.
         If ``escape`` is True, cell data will be passed through html.escape().
         """
-        html_output = "<table>"
+        html_output = '<table>'
         if dataset.headers is not None:
-            html_output += "<thead><tr>"
+            html_output += '<thead><tr>'
             for header in dataset.headers:
-                html_output += "<th>"
+                html_output += '<th>'
                 html_output += cls.format_str(header, escape=escape)
-                html_output += "</th>"
-            html_output += "</tr></thead>"
+                html_output += '</th>'
+            html_output += '</tr></thead>'
 
-        html_output += "<tbody>"
+        html_output += '<tbody>'
         for row in dataset:
-            html_output += "<tr>"
+            html_output += '<tr>'
             for item in row:
-                html_output += "<td>"
+                html_output += '<td>'
                 html_output += cls.format_str(item, escape=escape)
-                html_output += "</td>"
-            html_output += "</tr>"
-        html_output += "</tbody></table>"
+                html_output += '</td>'
+            html_output += '</tr>'
+        html_output += '</tbody></table>'
         return html_output
 
     @classmethod

--- a/src/tablib/formats/_html.py
+++ b/src/tablib/formats/_html.py
@@ -15,25 +15,25 @@ class HTMLFormat:
         """Returns HTML representation of Dataset.
         If ``escape`` is True, cell data will be passed through html.escape().
         """
-        html_output = '<table>'
+        s = '<table>'
         if dataset.headers is not None:
-            html_output += '<thead><tr>'
+            s += '<thead><tr>'
             for header in dataset.headers:
-                html_output += '<th>'
-                html_output += cls.format_str(header, escape=escape)
-                html_output += '</th>'
-            html_output += '</tr></thead>'
+                s += '<th>'
+                s += cls.format_str(header, escape=escape)
+                s += '</th>'
+            s += '</tr></thead>'
 
-        html_output += '<tbody>'
+        s += '<tbody>'
         for row in dataset:
-            html_output += '<tr>'
+            s += '<tr>'
             for item in row:
-                html_output += '<td>'
-                html_output += cls.format_str(item, escape=escape)
-                html_output += '</td>'
-            html_output += '</tr>'
-        html_output += '</tbody></table>'
-        return html_output
+                s += '<td>'
+                s += cls.format_str(item, escape=escape)
+                s += '</td>'
+            s += '</tr>'
+        s += '</tbody></table>'
+        return s
 
     @classmethod
     def export_book(cls, databook, escape=False):

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -752,6 +752,11 @@ class HTMLTests(BaseTestCase):
             tablib.import_set(html_input, format="html", table_id="notfound")
         self.assertEqual('No <table> found with id="notfound" in input HTML', str(exc.exception))
 
+    def test_html_export_with_special_chars(self):
+        self.founders = tablib.Dataset(headers=self.headers, title='Founders')
+        self.founders.append(('J &amp; J', 'A', 90))
+        self.assertIn("J &amp; J", self.founders.html)
+
 
 class RSTTests(BaseTestCase):
     def test_rst_force_grid(self):

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -752,10 +752,30 @@ class HTMLTests(BaseTestCase):
             tablib.import_set(html_input, format="html", table_id="notfound")
         self.assertEqual('No <table> found with id="notfound" in input HTML', str(exc.exception))
 
-    def test_html_export_with_special_chars(self):
+    def test_html_export_no_escape_special_chars(self):
         self.founders = tablib.Dataset(headers=self.headers, title='Founders')
         self.founders.append(('J &amp; J', 'A', 90))
         self.assertIn("J &amp; J", self.founders.html)
+
+    def test_html_export_escape_special_chars(self):
+        self.founders = tablib.Dataset(headers=self.headers, title='Founders')
+        self.founders.append(('J & J', 'A', 90))
+        expected = self.founders.export('html', escape=True)
+        self.assertIn("J &amp; J", expected)
+
+    def test_html_export_book_no_escape_special_chars(self):
+        book = tablib.Databook()
+        self.founders.append(('J &amp; J', 'A', 90))
+        book.add_sheet(self.founders)
+        expected = book.export('html', escape=False)
+        self.assertIn("J &amp; J", expected)
+
+    def test_html_export_book_escape_special_chars(self):
+        book = tablib.Databook()
+        self.founders.append(('J & J', 'A', 90))
+        book.add_sheet(self.founders)
+        expected = book.export('html', escape=True)
+        self.assertIn("J &amp; J", expected)
 
 
 class RSTTests(BaseTestCase):


### PR DESCRIPTION
Refactored HTML export to write a table without the need for any external dependency.  Dataset values can be optionally encoded.  This is to address issue #558.