### PR TITLE
Fix crash when loading databook from XLS

### DIFF
--- a/src/tablib/formats/_xls.py
+++ b/src/tablib/formats/_xls.py
@@ -100,7 +100,7 @@ class XLSFormat:
 
         dbook.wipe()
 
-        xls_book = xlrd.open_workbook(file_contents=in_stream)
+        xls_book = xlrd.open_workbook(file_contents=in_stream.read())
 
         for sheet in xls_book.sheets():
             data = tablib.Dataset()

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1147,6 +1147,11 @@ class XLSTests(BaseTestCase):
             ])
         )
 
+    def test_book_import_from_stream(self):
+        in_stream = self.founders.xls
+        book = tablib.Databook().load(in_stream, 'xls')
+        self.assertEqual(book.sheets()[0].title, 'Founders')
+
 
 class XLSXTests(BaseTestCase):
     def test_xlsx_format_detect(self):


### PR DESCRIPTION
`xlrd.open_workbook()` function expects the `file_contents` argument to be a string.

Fixes #522