### PR TITLE
Refactor `import datetime` as `import datetime as dt`

### DIFF
--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Tests for Tablib."""
 
-import datetime
+import datetime as dt
 import doctest
 import json
 import pickle
@@ -304,8 +304,8 @@ class TablibTestCase(BaseTestCase):
         """Passes in a single datetime and a single date and exports."""
 
         new_row = (
-            datetime.datetime.now(),
-            datetime.datetime.today(),
+            dt.datetime.now(),
+            dt.datetime.today(),
         )
 
         data.append(new_row)
@@ -1108,9 +1108,9 @@ class TSVTests(BaseTestCase):
 
 class ODSTests(BaseTestCase):
     def test_ods_export_import_set(self):
-        date = datetime.date(2019, 10, 4)
-        date_time = datetime.datetime(2019, 10, 4, 12, 30, 8)
-        time = datetime.time(14, 30)
+        date = dt.date(2019, 10, 4)
+        date_time = dt.datetime(2019, 10, 4, 12, 30, 8)
+        time = dt.time(14, 30)
         data.append(('string', '004', 42, 21.55, Decimal('34.5'), date, time, date_time))
         data.headers = (
             'string', 'start0', 'integer', 'float', 'decimal', 'date', 'time', 'date/time'
@@ -1165,7 +1165,7 @@ class XLSTests(BaseTestCase):
         xls_source = Path(__file__).parent / 'files' / 'dates.xls'
         with xls_source.open('rb') as fh:
             dset = tablib.Dataset().load(fh, 'xls')
-        self.assertEqual(dset.dict[0]['birth_date'], datetime.datetime(2015, 4, 12, 0, 0))
+        self.assertEqual(dset.dict[0]['birth_date'], dt.datetime(2015, 4, 12, 0, 0))
 
     def test_xlsx_import_set_skip_lines(self):
         data.append(('garbage', 'line', ''))
@@ -1203,7 +1203,7 @@ class XLSXTests(BaseTestCase):
         self.assertEqual(detect_format(in_stream), 'xlsx')
 
     def test_xlsx_import_set(self):
-        date_time = datetime.datetime(2019, 10, 4, 12, 30, 8)
+        date_time = dt.datetime(2019, 10, 4, 12, 30, 8)
         data.append(('string', '004', 42, 21.55, date_time))
         data.headers = ('string', 'start0', 'integer', 'float', 'date/time')
         _xlsx = data.xlsx

--- a/tests/test_tablib_dbfpy_packages_utils.py
+++ b/tests/test_tablib_dbfpy_packages_utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Tests for tablib.packages.dbfpy."""
 
-import datetime
+import datetime as dt
 import unittest
 
 from tablib.packages.dbfpy import utils
@@ -42,28 +42,28 @@ class UtilsGetDateTestCase(unittest.TestCase):
         output = utils.getDate(value)
 
         # Assert
-        self.assertIsInstance(output, datetime.date)
+        self.assertIsInstance(output, dt.date)
 
     def test_getDate_datetime_date(self):
         # Arrange
-        value = datetime.date(2019, 10, 19)
+        value = dt.date(2019, 10, 19)
 
         # Act
         output = utils.getDate(value)
 
         # Assert
-        self.assertIsInstance(output, datetime.date)
+        self.assertIsInstance(output, dt.date)
         self.assertEqual(output, value)
 
     def test_getDate_datetime_datetime(self):
         # Arrange
-        value = datetime.datetime(2019, 10, 19, 12, 00, 00)
+        value = dt.datetime(2019, 10, 19, 12, 00, 00)
 
         # Act
         output = utils.getDate(value)
 
         # Assert
-        self.assertIsInstance(output, datetime.date)
+        self.assertIsInstance(output, dt.date)
         self.assertEqual(output, value)
 
     def test_getDate_datetime_timestamp(self):
@@ -74,8 +74,8 @@ class UtilsGetDateTestCase(unittest.TestCase):
         output = utils.getDate(value)
 
         # Assert
-        self.assertIsInstance(output, datetime.date)
-        self.assertEqual(output, datetime.date(2019, 10, 19))
+        self.assertIsInstance(output, dt.date)
+        self.assertEqual(output, dt.date(2019, 10, 19))
 
     def test_getDate_datetime_string_yyyy_mm_dd(self):
         # Arrange
@@ -85,8 +85,8 @@ class UtilsGetDateTestCase(unittest.TestCase):
         output = utils.getDate(value)
 
         # Assert
-        self.assertIsInstance(output, datetime.date)
-        self.assertEqual(output, datetime.date(2019, 10, 19))
+        self.assertIsInstance(output, dt.date)
+        self.assertEqual(output, dt.date(2019, 10, 19))
 
     def test_getDate_datetime_string_yymmdd(self):
         # Arrange
@@ -96,8 +96,8 @@ class UtilsGetDateTestCase(unittest.TestCase):
         output = utils.getDate(value)
 
         # Assert
-        self.assertIsInstance(output, datetime.date)
-        self.assertEqual(output, datetime.date(2019, 10, 19))
+        self.assertIsInstance(output, dt.date)
+        self.assertEqual(output, dt.date(2019, 10, 19))
 
 
 class UtilsGetDateTimeTestCase(unittest.TestCase):
@@ -111,29 +111,29 @@ class UtilsGetDateTimeTestCase(unittest.TestCase):
         output = utils.getDateTime(value)
 
         # Assert
-        self.assertIsInstance(output, datetime.datetime)
+        self.assertIsInstance(output, dt.datetime)
 
     def test_getDateTime_datetime_datetime(self):
         # Arrange
-        value = datetime.datetime(2019, 10, 19, 12, 00, 00)
+        value = dt.datetime(2019, 10, 19, 12, 00, 00)
 
         # Act
         output = utils.getDateTime(value)
 
         # Assert
-        self.assertIsInstance(output, datetime.date)
+        self.assertIsInstance(output, dt.date)
         self.assertEqual(output, value)
 
     def test_getDateTime_datetime_date(self):
         # Arrange
-        value = datetime.date(2019, 10, 19)
+        value = dt.date(2019, 10, 19)
 
         # Act
         output = utils.getDateTime(value)
 
         # Assert
-        self.assertIsInstance(output, datetime.date)
-        self.assertEqual(output, datetime.datetime(2019, 10, 19, 00, 00))
+        self.assertIsInstance(output, dt.date)
+        self.assertEqual(output, dt.datetime(2019, 10, 19, 00, 00))
 
     def test_getDateTime_datetime_timestamp(self):
         # Arrange
@@ -143,7 +143,7 @@ class UtilsGetDateTimeTestCase(unittest.TestCase):
         output = utils.getDateTime(value)
 
         # Assert
-        self.assertIsInstance(output, datetime.datetime)
+        self.assertIsInstance(output, dt.datetime)
 
     def test_getDateTime_datetime_string(self):
         # Arrange


### PR DESCRIPTION
Follow on from https://github.com/jazzband/tablib/pull/568#discussion_r1375298382.

Refactor `import datetime` as `import datetime as dt` to avoid ambiguity between the `datetime` module and class:

* https://adamj.eu/tech/2019/09/12/how-i-import-pythons-datetime-module/