### PR TITLE
Removed OrderedDict usage

### DIFF
--- a/src/tablib/core.py
+++ b/src/tablib/core.py
@@ -8,7 +8,6 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from collections import OrderedDict
 from copy import copy
 from operator import itemgetter
 
@@ -265,16 +264,11 @@ class Dataset:
                 raise InvalidDimensions
             return False
 
-    def _package(self, dicts=True, ordered=True):
+    def _package(self, dicts=True):
         """Packages Dataset into lists of dictionaries for transmission."""
         # TODO: Dicts default to false?
 
         _data = list(self._data)
-
-        if ordered:
-            dict_pack = OrderedDict
-        else:
-            dict_pack = dict
 
         # Execute formatters
         if self._formatters:
@@ -291,7 +285,7 @@ class Dataset:
 
         if self.headers:
             if dicts:
-                data = [dict_pack(list(zip(self.headers, data_row))) for data_row in _data]
+                data = [dict(list(zip(self.headers, data_row))) for data_row in _data]
             else:
                 data = [list(self.headers)] + list(_data)
         else:
@@ -883,20 +877,15 @@ class Databook:
         else:
             raise InvalidDatasetType
 
-    def _package(self, ordered=True):
+    def _package(self):
         """Packages :class:`Databook` for delivery."""
         collector = []
 
-        if ordered:
-            dict_pack = OrderedDict
-        else:
-            dict_pack = dict
-
         for dset in self._datasets:
-            collector.append(dict_pack(
-                title=dset.title,
-                data=dset._package(ordered=ordered)
-            ))
+            collector.append({
+                'title': dset.title,
+                'data': dset._package()
+            })
         return collector
 
     @property

--- a/src/tablib/formats/__init__.py
+++ b/src/tablib/formats/__init__.py
@@ -1,6 +1,5 @@
 """ Tablib - formats
 """
-from collections import OrderedDict
 from functools import partialmethod
 from importlib import import_module
 from importlib.util import find_spec
@@ -65,7 +64,7 @@ class ImportExportSetDescriptor(FormatDescriptorBase):
 
 
 class Registry:
-    _formats = OrderedDict()
+    _formats = {}
 
     def register(self, key, format_or_path):
         from ..core import Databook, Dataset

--- a/src/tablib/formats/_yaml.py
+++ b/src/tablib/formats/_yaml.py
@@ -14,14 +14,14 @@ class YAMLFormat:
     def export_set(cls, dataset):
         """Returns YAML representation of Dataset."""
         return yaml.safe_dump(
-            dataset._package(ordered=False), default_flow_style=None, allow_unicode=True
+            dataset._package(), default_flow_style=None, allow_unicode=True
         )
 
     @classmethod
     def export_book(cls, databook):
         """Returns YAML representation of Databook."""
         return yaml.safe_dump(
-            databook._package(ordered=False), default_flow_style=None, allow_unicode=True
+            databook._package(), default_flow_style=None, allow_unicode=True
         )
 
     @classmethod

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -7,7 +7,6 @@ import json
 import pickle
 import tempfile
 import unittest
-from collections import OrderedDict
 from decimal import Decimal
 from io import BytesIO, StringIO
 from pathlib import Path
@@ -1211,7 +1210,7 @@ class XLSTests(BaseTestCase):
             data = tablib.Dataset().load(fh.read())
         self.assertEqual(
             data.dict[0],
-            OrderedDict([
+            dict([
                 ('div by 0', '#DIV/0!'),
                 ('name unknown', '#NAME?'),
                 ('not available (formula)', '#N/A'),


### PR DESCRIPTION
Plain dicts are ordered since Python 3.6.