### PR TITLE
Add optional requirement specifier "html" back

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ Here is a list of past and present much-appreciated contributors:
     Mark Walling
     Mathias Loesch
     Matthew Hegarty
+    Matthias Dellweg
     Mike Waldner
     Peyman Salehi
     Rabin Nankhwa

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+## 3.6.1 (2024-04-04)
+
+### Bugfixes
+
+- Fix broken installs with pip failing to resolve the request for `tablib[html]` in some cases (#588).
+
 ## 3.6.0 (2024-03-23)
 
 ### Improvements
@@ -48,7 +54,7 @@
 
 - Fix bug when yaml file is empty (#535)
 - Fix linting issues raised by Flake8 (#536)
- 
+
 ## 3.3.0 (2022-12-10)
 
 ### Improvements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ all = [
     "xlwt",
 ]
 cli = ["tabulate"]
+html = []
 ods = ["odfpy"]
 pandas = ["pandas"]
 xls = ["xlrd", "xlwt"]


### PR DESCRIPTION
Removing such a specifier should be considered a breaking change and be postponed to the next major release, because `pip install tablib[html]` fails on this. Since there are no actual dependencies to consider, an empty list is put behind that key.

fixes #588