### PR TITLE
Exclude bots from generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
When "Click "Generate release notes" (https://github.com/jazzband/tablib/blob/master/RELEASING.md), by default it includes any bot contributions like pre-commit.

See https://github.com/tox-dev/tox-ini-fmt/pull/120 for a more extreme example.

We don't need to include those in the generated release notes, so here's config to exclude them.