### PR TITLE
Defer imports to improve startup speed

### DIFF
--- a/src/tablib/core.py
+++ b/src/tablib/core.py
@@ -8,9 +8,6 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from copy import copy
-from operator import itemgetter
-
 from .exceptions import (
     HeadersNeeded,
     InvalidDatasetIndex,
@@ -638,6 +635,8 @@ class Dataset:
         """Returns a new instance of the :class:`Dataset`, excluding any rows
         that do not contain the given :ref:`tags <tags>`.
         """
+        import copy
+
         _dset = copy(self)
         _dset._data = [row for row in _dset._data if row.has_tag(tag)]
 
@@ -651,6 +650,7 @@ class Dataset:
         Returns a new :class:`Dataset` instance where columns have been
         sorted.
         """
+        from operator import itemgetter
 
         if isinstance(col, str):
 
@@ -745,6 +745,8 @@ class Dataset:
             raise InvalidDimensions
 
         # Copy the source data
+        from copy import copy
+
         _dset = copy(self)
 
         rows_to_stack = [row for row in _dset._data]

--- a/src/tablib/formats/_csv.py
+++ b/src/tablib/formats/_csv.py
@@ -1,7 +1,6 @@
 """ Tablib - *SV Support.
 """
 
-import csv
 from io import StringIO
 
 
@@ -14,6 +13,8 @@ class CSVFormat:
     @classmethod
     def export_stream_set(cls, dataset, **kwargs):
         """Returns CSV representation of Dataset as file-like."""
+        import csv
+
         stream = StringIO()
 
         kwargs.setdefault('delimiter', cls.DEFAULT_DELIMITER)
@@ -35,6 +36,7 @@ class CSVFormat:
     @classmethod
     def import_set(cls, dset, in_stream, headers=True, skip_lines=0, **kwargs):
         """Returns dataset from CSV stream."""
+        import csv
 
         dset.wipe()
 
@@ -54,6 +56,8 @@ class CSVFormat:
     @classmethod
     def detect(cls, stream, delimiter=None):
         """Returns True if given stream is valid CSV."""
+        import csv
+
         try:
             csv.Sniffer().sniff(stream.read(2048), delimiters=delimiter or cls.DEFAULT_DELIMITER)
             return True

--- a/src/tablib/formats/_json.py
+++ b/src/tablib/formats/_json.py
@@ -1,13 +1,12 @@
 """ Tablib - JSON Support
 """
-import decimal
-import json
-from uuid import UUID
-
 import tablib
 
 
 def serialize_objects_handler(obj):
+    import decimal
+    from uuid import UUID
+
     if isinstance(obj, (decimal.Decimal, UUID)):
         return str(obj)
     elif hasattr(obj, 'isoformat'):
@@ -23,6 +22,8 @@ class JSONFormat:
     @classmethod
     def export_set(cls, dataset):
         """Returns JSON representation of Dataset."""
+        import json
+
         return json.dumps(
             dataset.dict, default=serialize_objects_handler, ensure_ascii=False
         )
@@ -30,6 +31,8 @@ class JSONFormat:
     @classmethod
     def export_book(cls, databook):
         """Returns JSON representation of Databook."""
+        import json
+
         return json.dumps(
             databook._package(), default=serialize_objects_handler, ensure_ascii=False
         )
@@ -37,6 +40,7 @@ class JSONFormat:
     @classmethod
     def import_set(cls, dset, in_stream):
         """Returns dataset from JSON stream."""
+        import json
 
         dset.wipe()
         dset.dict = json.load(in_stream)
@@ -44,6 +48,7 @@ class JSONFormat:
     @classmethod
     def import_book(cls, dbook, in_stream):
         """Returns databook from JSON stream."""
+        import json
 
         dbook.wipe()
         for sheet in json.load(in_stream):
@@ -55,6 +60,8 @@ class JSONFormat:
     @classmethod
     def detect(cls, stream):
         """Returns True if given stream is valid JSON."""
+        import json
+
         try:
             json.load(stream)
             return True


### PR DESCRIPTION
It can be useful to defer imports so that when people import tablib but don't use certain features (for example, if they don't use JSON format) they can avoid the import cost.

This particularly helps people writing tools like CLIs where startup cost can be a problem.

If people are using tablib and other libraries, the total import times can all add up.

We've been doing this also in the stdlib, for example:

* 3.13: https://github.com/python/cpython/issues/109653
* 3.14: https://github.com/python/cpython/issues/118761

Running:

```sh
python3 -X importtime -c 'import tablib' 2> import.log
pip install tuna
tuna import.log
```

# Before: 8 ms

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/48944125-b7da-4710-9fa1-5f57d31c81ae" />


# After: 2 ms

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/3a480b6e-d011-4701-8f58-6537688fbca3" />
