### PR TITLE
Remove outdated Python support from docs

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -51,3 +51,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 .. _`The MIT License`: https://opensource.org/licenses/mit-license.php
+
+Now, go :ref:`install Tablib <install>`.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -51,12 +51,3 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 .. _`The MIT License`: https://opensource.org/licenses/mit-license.php
-
-.. _pythonsupport:
-
-Pythons Supported
------------------
-
-Python 3.6+ is officially supported.
-
-Now, go :ref:`install Tablib <install>`.


### PR DESCRIPTION
Fixes https://github.com/jazzband/tablib/issues/610.

Refer to `pyproject.toml` metadata instead.

https://github.com/jazzband/tablib/blob/51e24c2c9f0798df134ae39326a9595a839423f4/pyproject.toml#L18-L31