### PR TITLE
Fix bug in ODS import where headers are not set on Dataset

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Here is a list of past and present much-appreciated contributors:
     Egor Osokin
     Erik Youngren
     Hugo van Kemenade
+    Ian Stride
     Iuri de Silvio
     Jakub Janoszek
     James Douglass

--- a/src/tablib/formats/_ods.py
+++ b/src/tablib/formats/_ods.py
@@ -113,9 +113,9 @@ class ODSFormat:
         def is_real_cell(cell):
             return cell.hasChildNodes() or not cell.getAttribute('numbercolumnsrepeated')
 
-        for i, row in enumerate(sheet.childNodes):
-            if row.tagName != 'table:table-row':
-                continue
+        rows = (row for row in sheet.childNodes if row.tagName == "table:table-row")
+
+        for i, row in enumerate(rows):
             if i < skip_lines:
                 continue
             row_vals = [cls.read_cell(cell) for cell in row.childNodes if is_real_cell(cell)]

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1246,6 +1246,7 @@ class ODSTests(BaseTestCase):
         with ods_source.open('rb') as fh:
             dbook = tablib.Databook().load(fh, 'ods')
         self.assertEqual(len(dbook.sheets()), 2)
+        self.assertEqual(["This", "is", "a", "second", "sheet"], dbook.sheets()[1].headers)
 
     def test_ods_import_set_skip_lines(self):
         data.append(('garbage', 'line', ''))
@@ -1266,7 +1267,7 @@ class ODSTests(BaseTestCase):
         # <table:table-cell office:value-type="unknown" calcext:value-type="string">
         ods_source = Path(__file__).parent / 'files' / 'unknown_value_type.ods'
         with ods_source.open('rb') as fh:
-            dataset = tablib.Dataset().load(fh, 'ods')
+            dataset = tablib.Dataset().load(fh, 'ods', headers=False)
         self.assertEqual(dataset.pop(), ('abcd',))
 
     def test_ods_export_dates(self):


### PR DESCRIPTION
Sheets in ODS files saved by LibreOffice can contain 'table-column' nodes before the 'table-row' nodes. Previously, all child nodes of a sheet where enumerated before iterating over them, leading to incorrect counting of skipped rows and failed identification of the headers row.

This change creates a generator that returns 'table-row' nodes only, before they are enumerated and iterated over.