### PR TITLE
Improve comprehensions

### DIFF
--- a/src/tablib/_vendor/dbfpy/record.py
+++ b/src/tablib/_vendor/dbfpy/record.py
@@ -242,7 +242,7 @@ class DbfRecord:
             real values stored in this object.
 
         """
-        return dict([_i for _i in zip(self.dbf.fieldNames, self.fieldData)])
+        return dict(list(zip(self.dbf.fieldNames, self.fieldData)))
 
     def __getitem__(self, key):
         """Return value by field name or field index."""

--- a/src/tablib/core.py
+++ b/src/tablib/core.py
@@ -148,7 +148,7 @@ class Dataset:
     """
 
     def __init__(self, *args, **kwargs):
-        self._data = list(Row(arg) for arg in args)
+        self._data = [Row(arg) for arg in args]
         self.__headers = None
 
         # ('title', index) tuples

--- a/src/tablib/core.py
+++ b/src/tablib/core.py
@@ -798,7 +798,7 @@ class Dataset:
 
     def wipe(self):
         """Removes all content and headers from the :class:`Dataset` object."""
-        self._data = list()
+        self._data = []
         self.__headers = None
 
     def subset(self, rows=None, cols=None):

--- a/src/tablib/core.py
+++ b/src/tablib/core.py
@@ -747,8 +747,8 @@ class Dataset:
         # Copy the source data
         _dset = copy(self)
 
-        rows_to_stack = [row for row in _dset._data]
-        other_rows = [row for row in other._data]
+        rows_to_stack = list(_dset._data)
+        other_rows = list(other._data)
 
         rows_to_stack.extend(other_rows)
         _dset._data = rows_to_stack

--- a/src/tablib/formats/_latex.py
+++ b/src/tablib/formats/_latex.py
@@ -54,8 +54,8 @@ class LATEXFormat:
         header = cls._serialize_row(dataset.headers) if dataset.headers else ''
         midrule = cls._midrule(dataset.width)
         body = '\n'.join([cls._serialize_row(row) for row in dataset])
-        return cls.TABLE_TEMPLATE % dict(CAPTION=caption, COLSPEC=colspec,
-                                         HEADER=header, MIDRULE=midrule, BODY=body)
+        return cls.TABLE_TEMPLATE % {'CAPTION': caption, 'COLSPEC': colspec,
+                                     'HEADER': header, 'MIDRULE': midrule, 'BODY': body}
 
     @classmethod
     def _colspec(cls, dataset_width):

--- a/src/tablib/formats/_latex.py
+++ b/src/tablib/formats/_latex.py
@@ -25,18 +25,18 @@ class LATEXFormat:
 \\end{table}
 """
 
-    TEX_RESERVED_SYMBOLS_MAP = dict([
-        ('\\', '\\textbackslash{}'),
-        ('{', '\\{'),
-        ('}', '\\}'),
-        ('$', '\\$'),
-        ('&', '\\&'),
-        ('#', '\\#'),
-        ('^', '\\textasciicircum{}'),
-        ('_', '\\_'),
-        ('~', '\\textasciitilde{}'),
-        ('%', '\\%'),
-    ])
+    TEX_RESERVED_SYMBOLS_MAP = {
+        '\\': '\\textbackslash{}',
+        '{': '\\{',
+        '}': '\\}',
+        '$': '\\$',
+        '&': '\\&',
+        '#': '\\#',
+        '^': '\\textasciicircum{}',
+        '_': '\\_',
+        '~': '\\textasciitilde{}',
+        '%': '\\%',
+    }
 
     TEX_RESERVED_SYMBOLS_RE = re.compile(
         '(%s)' % '|'.join(map(re.escape, TEX_RESERVED_SYMBOLS_MAP.keys())))

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -141,7 +141,7 @@ class TablibTestCase(BaseTestCase):
 
         data.append_col(new_col)
 
-        self.assertEqual(data[0], tuple([new_col[0]]))
+        self.assertEqual(data[0], (new_col[0],))
         self.assertEqual(data.width, 1)
         self.assertEqual(data.height, len(new_col))
 
@@ -154,7 +154,7 @@ class TablibTestCase(BaseTestCase):
 
         data.append_col(new_col, header='first_name')
 
-        self.assertEqual(data[0], tuple([new_col[0]]))
+        self.assertEqual(data[0], (new_col[0],))
         self.assertEqual(data.width, 1)
         self.assertEqual(data.height, len(new_col))
         self.assertEqual(data.headers, None)

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1318,12 +1318,12 @@ class XLSTests(BaseTestCase):
             data = tablib.Dataset().load(fh.read())
         self.assertEqual(
             data.dict[0],
-            dict([
-                ('div by 0', '#DIV/0!'),
-                ('name unknown', '#NAME?'),
-                ('not available (formula)', '#N/A'),
-                ('not available (static)', '#N/A')
-            ])
+            {
+                'div by 0': '#DIV/0!',
+                'name unknown': '#NAME?',
+                'not available (formula)': '#N/A',
+                'not available (static)': '#N/A',
+            }
         )
 
     def test_book_import_from_stream(self):

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1108,7 +1108,7 @@ class CSVTests(BaseTestCase):
 
         expected = 'first_name;last_name;gpa\nJohn;Adams;90\nGeorge;Washington;67\n'
 
-        kwargs = dict(delimiter=';', lineterminator='\n')
+        kwargs = {'delimiter': ';', 'lineterminator': '\n'}
         _csv = data.export('csv', **kwargs)
         self.assertEqual(expected, _csv)
 


### PR DESCRIPTION
These are more efficient. Identified with the flake8-comprehensions (C4) tool in Ruff:

https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4

We could also add the flake8-comprehensions plugin to our config, or even the Ruff equivalent for more efficient linting as well?