### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -19,10 +19,10 @@ jobs:
         - TOXENV: lint
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
           cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
           cache: pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -41,6 +41,6 @@ jobs:
         tox -e py
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+## 3.9.0 (unreleased)
+
+### Improvements
+
+- Drop support for EOL Python 3.9 (#628)
+
 ## 3.8.0 (2025-01-22)
 
 ### Improvements

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,16 @@
 # History
 
-## 3.9.0 (unreleased)
+## 3.10.0 (unreleased)
 
 ### Improvements
 
 - Drop support for EOL Python 3.9 (#628)
+
+## 3.9.0 (unreleased)
+
+### Improvements
+
+- TODO
 
 ## 3.8.0 (2025-01-22)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
     {name = "Hugo van Kemenade"},
     {name = "Claude Paroz", email = "claude@2xlibre.net"},
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -24,7 +24,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ minversion = 2.4
 envlist =
     docs
     lint
-    py{39,310,311,312,313,314}
+    py{310,311,312,313,314}
 
 [testenv]
 deps =


### PR DESCRIPTION
It's almost end-of-life:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0596/

Also bump GitHub Actions.