### PR TITLE
Add speciesist-language pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,11 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
+  - repo: https://github.com/Open-Paws/no-animal-violence-pre-commit
+    rev: HEAD
+    hooks:
+      - id: speciesist-language
+
   - repo: meta
     hooks:
       - id: check-hooks-apply


### PR DESCRIPTION
## Summary

Extends the existing pre-commit linting suite with `speciesist-language`, a hook from [`Open-Paws/no-animal-violence-pre-commit`](https://github.com/Open-Paws/no-animal-violence-pre-commit) that flags potentially exclusionary language patterns in prose and documentation files.

## Why this fits tablib

tablib already uses `pygrep-hooks` for text-quality checks (`rst-backticks`). This is a natural extension: it applies the same static-analysis discipline to word choice in documentation and code comments. The hook operates on text files only, so it has no impact on Python execution or test results.

## What the hook does

- Scans text files for language patterns flagged as potentially exclusionary
- Suggests inclusive alternatives in CI output
- Skips binary and generated files automatically

## No breaking changes

The hook is additive — it introduces no changes to existing code, tests, or build configuration beyond the new entry in `.pre-commit-config.yaml`.