### PR TITLE
Prevent XLS precision loss for large integers

### DIFF
--- a/src/tablib/formats/_xls.py
+++ b/src/tablib/formats/_xls.py
@@ -150,6 +150,12 @@ class XLSFormat:
         for i, row in enumerate(_package):
             for j, col in enumerate(row):
 
+                # Convert large ints to str to avoid XLS float precision loss
+                # (XLS uses 64-bit floats: precision is limited to ~15 digits)
+                if isinstance(col, int) and not isinstance(col, bool):
+                    if abs(col) > 9007199254740991:  # 2^53 - 1
+                        col = str(col)
+
                 # bold headers
                 if (i == 0) and dataset.headers:
                     ws.write(i, j, col, bold)


### PR DESCRIPTION
## Summary
- prevent precision loss when exporting large integers to XLS format
- integers exceeding XLS float precision (2^53 - 1) are now stored as text strings

## Problem
XLS (Excel 97-2003) stores numeric values as 64-bit IEEE 754 floats with a 53-bit mantissa. Integers larger than 9,007,199,254,740,991 (2^53 - 1) lose precision when stored as numbers. For example, `568883383628111872` becomes `568883383628112000`.

## Fix
In `dset_sheet`, detect integers that exceed the float precision limit and convert them to strings before writing. Small integers continue to be stored as numbers for normal behavior.

## Testing
Verified that:
- Large integers (e.g., `568883383628111872`) are stored as text (cell type 1) and read back with full precision
- Small integers (e.g., `42`) continue to be stored as numbers (cell type 2)
- Boolean values are unaffected (not coerced to string)

Fixes #197
