### PR TITLE
Auto-detect CSV delimiter via `Sniffer` in `import_set` and `detect()`

### DIFF
--- a/src/tablib/formats/_csv.py
+++ b/src/tablib/formats/_csv.py
@@ -38,7 +38,27 @@ class CSVFormat:
 
         dset.wipe()
 
-        kwargs.setdefault('delimiter', cls.DEFAULT_DELIMITER)
+        if 'delimiter' not in kwargs:
+            # Auto-detect the delimiter using the CSV Sniffer.
+            # Reading a sample and then seeking back to the start lets the
+            # Sniffer work on real data while keeping the stream intact for
+            # the subsequent csv.reader call.  Crucially, we do NOT restrict
+            # sniffing to a single delimiter so that files using non-comma
+            # separators (e.g. ';', ':', '|') are imported correctly.  See #622.
+            try:
+                sample = in_stream.read(2048)
+                dialect = csv.Sniffer().sniff(sample)
+                # Only accept non-word-character delimiters (true separators
+                # such as ',', ';', '|', ':', '\t').  The Sniffer occasionally
+                # misidentifies a letter as a delimiter when the sample is short
+                # or ambiguous; falling back to the default in that case is safer.
+                if dialect.delimiter.isalpha() or dialect.delimiter.isdigit():
+                    raise csv.Error("unlikely delimiter detected, falling back")
+                kwargs['delimiter'] = dialect.delimiter
+            except csv.Error:
+                kwargs['delimiter'] = cls.DEFAULT_DELIMITER
+            if hasattr(in_stream, 'seek'):
+                in_stream.seek(0)
 
         rows = csv.reader(in_stream, **kwargs)
         for i, row in enumerate(rows):
@@ -55,7 +75,22 @@ class CSVFormat:
     def detect(cls, stream, delimiter=None):
         """Returns True if given stream is valid CSV."""
         try:
-            csv.Sniffer().sniff(stream.read(2048), delimiters=delimiter or cls.DEFAULT_DELIMITER)
+            # When no explicit delimiter is given, build a candidate list that
+            # includes the format's own DEFAULT_DELIMITER plus common non-tab
+            # separators.  For CSVFormat this covers ',', ';', ':', '|' while
+            # keeping tab-delimited files out of CSV detection (tab-delimited
+            # files belong to TSVFormat).  TSVFormat overrides DEFAULT_DELIMITER
+            # to '\t' so it will still detect tab-delimited content correctly.
+            # See #622.
+            if delimiter is None:
+                common = ',;:|'
+                sniff_delimiters = (
+                    common if cls.DEFAULT_DELIMITER in common
+                    else cls.DEFAULT_DELIMITER
+                )
+            else:
+                sniff_delimiters = delimiter
+            csv.Sniffer().sniff(stream.read(2048), delimiters=sniff_delimiters)
             return True
         except Exception:
             return False

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1112,12 +1112,37 @@ class CSVTests(BaseTestCase):
         _csv = data.export('csv', **kwargs)
         self.assertEqual(expected, _csv)
 
-        # the import works but consider default delimiter=','
+        # Auto-detection picks up the ';' delimiter, so all three headers are found.
         d1 = tablib.import_set(_csv, format="csv")
-        self.assertEqual(1, len(d1.headers))
+        self.assertEqual(3, len(d1.headers))
 
         d2 = tablib.import_set(_csv, format="csv", **kwargs)
         self.assertEqual(3, len(d2.headers))
+
+    def test_csv_import_set_auto_detect_delimiter(self):
+        """CSV import auto-detects non-comma delimiters via Sniffer. Regression for #622."""
+        from io import StringIO
+
+        # Colon-delimited (the exact case from issue #622)
+        colon_csv = StringIO('header1:header2\nvalue1:value2\n')
+        dataset = tablib.Dataset().load(colon_csv, format='csv')
+        self.assertEqual(dataset.headers, ['header1', 'header2'])
+        self.assertEqual(dataset[0], ('value1', 'value2'))
+
+        # Pipe-delimited
+        pipe_csv = 'Name|Age|City\nAlice|30|NYC\nBob|25|LA\n'
+        dataset2 = tablib.import_set(pipe_csv, format='csv')
+        self.assertEqual(dataset2.headers, ['Name', 'Age', 'City'])
+        self.assertEqual(dataset2[0], ('Alice', '30', 'NYC'))
+
+    def test_csv_detect_non_comma_delimiter(self):
+        """CSV format detection works for non-comma delimiters. Regression for #622."""
+        from io import StringIO
+
+        fmt = registry.get_format('csv')
+        self.assertTrue(fmt.detect(StringIO('a:b:c\n1:2:3\n')))
+        self.assertTrue(fmt.detect(StringIO('Name|Age|City\nAlice|30|NYC\n')))
+        self.assertTrue(fmt.detect(StringIO('a;b;c\n1;2;3\n')))
 
 
 class TSVTests(BaseTestCase):


### PR DESCRIPTION
Fixes #622

## Problem

`tablib.Dataset().load(data, format='csv')` always uses `,` as the delimiter, even when the file uses `;`, `:`, `|`, or other separators. This is because `import_set` calls `kwargs.setdefault('delimiter', cls.DEFAULT_DELIMITER)` without ever sniffing the actual content.

A secondary issue: `CSVFormat.detect()` passed `delimiters=delimiter or cls.DEFAULT_DELIMITER` to `csv.Sniffer().sniff()`, which restricted sniffing to comma-only. This meant non-comma CSV files were never recognised during format auto-detection.

## Fix

**import_set**: when no `delimiter` kwarg is provided, read up to 2048 bytes as a sample, call `csv.Sniffer().sniff(sample)` with no delimiter restriction, and use the detected delimiter. The stream is then seeked back to 0 before the actual read. A guard rejects alphabetic/digit detections (the Sniffer occasionally misidentifies a letter on very short or ambiguous samples). Falls back to `DEFAULT_DELIMITER` on any `csv.Error`.

**detect()**: when no explicit delimiter is given, uses a candidate string of common non-tab separators (',;:|') for CSVFormat, and the format's `DEFAULT_DELIMITER` for subclasses (e.g. TSVFormat uses tab). This keeps tab-delimited files out of CSV auto-detection while still recognising `;`, `:`, and `|` separated files.

Explicit `delimiter` kwargs are fully respected and take precedence.

## Tests

- Updated `test_csv_formatter_support_kwargs`: old assertion documented the broken behaviour (1 header instead of 3); updated to assert correct parsing.
- Added `test_csv_import_set_auto_detect_delimiter`: colon- and pipe-delimited CSV auto-detection.
- Added `test_csv_detect_non_comma_delimiter`: `detect()` correctly recognises `:`, `|`, and `;` separated files.

All 155 tests pass.