### PR TITLE
Remove `#yaml` tag from generic error message URL

### DIFF
--- a/src/tablib/core.py
+++ b/src/tablib/core.py
@@ -338,7 +338,7 @@ class Dataset:
         """
         error_details = (
             "Please check format documentation "
-            "https://tablib.readthedocs.io/en/stable/formats.html#yaml"
+            "https://tablib.readthedocs.io/en/stable/formats.html"
         )
 
         if not pickle:


### PR DESCRIPTION
This error isn't `yaml`-specific.  Looks like this got committed (without PR?) as part of addressing https://github.com/jazzband/tablib/issues/524 and perhaps bypassed PR/review: https://github.com/jazzband/tablib/commit/0a3511fb9789b2e9f0d58739fccffde8db9f2635#diff-026edabea10cc8f56b3dc11a795a25d0bdc86ae602fc6649cd30730b5624ba78R336-L353

Possible there are other related changes around this code that should be made too, but seemed like fixing the misleading error message might help a little.  Here's another later related commit:  https://github.com/jazzband/tablib/commit/b2be12e5b647111d8e0f24c8bab646a97a3d68f2