### PR TITLE
Added PEP 484 type hints to the four public methods in CSVFormat (src/tablib/formats/_csv.py).

### DIFF
--- a/src/tablib/formats/_csv.py
+++ b/src/tablib/formats/_csv.py
@@ -3,7 +3,7 @@
 
 import csv
 from io import StringIO
-from typing import Any, Optional, TextIO
+from typing import Any, TextIO
 
 
 class CSVFormat:
@@ -34,7 +34,9 @@ class CSVFormat:
         return stream.getvalue()
 
     @classmethod
-    def import_set(cls, dset: Any, in_stream: TextIO, headers: bool = True, skip_lines: int = 0, **kwargs: Any) -> None:
+    def import_set(
+        cls, dset: Any, in_stream: TextIO, headers: bool = True, skip_lines: int = 0, **kwargs: Any
+    ) -> None:
         """Returns dataset from CSV stream."""
 
         dset.wipe()
@@ -53,7 +55,7 @@ class CSVFormat:
                 dset.append(row)
 
     @classmethod
-    def detect(cls, stream: TextIO, delimiter: Optional[str] = None) -> bool:
+    def detect(cls, stream: TextIO, delimiter: str | None = None) -> bool:
         """Returns True if given stream is valid CSV."""
         try:
             csv.Sniffer().sniff(stream.read(2048), delimiters=delimiter or cls.DEFAULT_DELIMITER)

--- a/src/tablib/formats/_csv.py
+++ b/src/tablib/formats/_csv.py
@@ -3,7 +3,7 @@
 
 import csv
 from io import StringIO
-from typing import Any, Optional, TextIO
+from typing import Any, TextIO
 
 
 class CSVFormat:
@@ -53,11 +53,10 @@ class CSVFormat:
                 dset.append(row)
 
     @classmethod
-    def detect(cls, stream: TextIO, delimiter: Optional[str] = None) -> bool:
+    def detect(cls, stream: TextIO, delimiter: str | None = None) -> bool:
         """Returns True if given stream is valid CSV."""
         try:
             csv.Sniffer().sniff(stream.read(2048), delimiters=delimiter or cls.DEFAULT_DELIMITER)
             return True
         except Exception:
             return False
-

--- a/src/tablib/formats/_csv.py
+++ b/src/tablib/formats/_csv.py
@@ -3,6 +3,7 @@
 
 import csv
 from io import StringIO
+from typing import Any, Optional, TextIO
 
 
 class CSVFormat:
@@ -12,7 +13,7 @@ class CSVFormat:
     DEFAULT_DELIMITER = ','
 
     @classmethod
-    def export_stream_set(cls, dataset, **kwargs):
+    def export_stream_set(cls, dataset: Any, **kwargs: Any) -> StringIO:
         """Returns CSV representation of Dataset as file-like."""
         stream = StringIO()
 
@@ -27,13 +28,13 @@ class CSVFormat:
         return stream
 
     @classmethod
-    def export_set(cls, dataset, **kwargs):
+    def export_set(cls, dataset: Any, **kwargs: Any) -> str:
         """Returns CSV representation of Dataset."""
         stream = cls.export_stream_set(dataset, **kwargs)
         return stream.getvalue()
 
     @classmethod
-    def import_set(cls, dset, in_stream, headers=True, skip_lines=0, **kwargs):
+    def import_set(cls, dset: Any, in_stream: TextIO, headers: bool = True, skip_lines: int = 0, **kwargs: Any) -> None:
         """Returns dataset from CSV stream."""
 
         dset.wipe()
@@ -52,10 +53,11 @@ class CSVFormat:
                 dset.append(row)
 
     @classmethod
-    def detect(cls, stream, delimiter=None):
+    def detect(cls, stream: TextIO, delimiter: Optional[str] = None) -> bool:
         """Returns True if given stream is valid CSV."""
         try:
             csv.Sniffer().sniff(stream.read(2048), delimiters=delimiter or cls.DEFAULT_DELIMITER)
             return True
         except Exception:
             return False
+


### PR DESCRIPTION
Adds PEP 484 type hints to the four public methods in CSVFormat (src/tablib/formats/_csv.py). No logic or docstring changes.

Signatures:
export_stream_set(dataset: Any, **kwargs: Any) -> StringIO
export_set(dataset: Any, **kwargs: Any) -> str
import_set(dset: Any, in_stream: TextIO, headers: bool, skip_lines: int, **kwargs: Any) -> None
detect(stream: TextIO, delimiter: Optional[str]) -> bool

Generated and verified with Symbiote, an internal AI-assisted annotation pipeline that maps the import graph and inserts typing without touching executable logic. Flagging that up front in case it matters for review.

Open to tightening any of the `Any` annotations if narrower types make sense here.