### PR TITLE
Preserve falsy values (0, False) in jira and latex exports

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Here is a list of past and present much-appreciated contributors:
     Joel Friedly
     Josh Ourisman
     Kenneth Reitz
+    kigland
     Luca Beltrame
     Luke Lee
     Marc Abramowitz

--- a/src/tablib/formats/_jira.py
+++ b/src/tablib/formats/_jira.py
@@ -2,6 +2,7 @@
 
    Generates a Jira table from the dataset.
 """
+from tablib.utils import is_empty_cell
 
 
 class JIRAFormat:
@@ -35,16 +36,6 @@ class JIRAFormat:
     def _serialize_row(cls, row, delimiter='|'):
         return '{}{}{}'.format(
             delimiter,
-            delimiter.join([' ' if cls._is_empty_value(item) else str(item) for item in row]),
+            delimiter.join([' ' if is_empty_cell(item) else str(item) for item in row]),
             delimiter
         )
-
-    @classmethod
-    def _is_empty_value(cls, item):
-        if item is None:
-            return True
-        if isinstance(item, (str, bytes, bytearray)):
-            return len(item) == 0
-        if isinstance(item, (list, tuple, dict, set, frozenset)):
-            return len(item) == 0
-        return False

--- a/src/tablib/formats/_jira.py
+++ b/src/tablib/formats/_jira.py
@@ -35,6 +35,6 @@ class JIRAFormat:
     def _serialize_row(cls, row, delimiter='|'):
         return '{}{}{}'.format(
             delimiter,
-            delimiter.join([str(item) if item else ' ' for item in row]),
+            delimiter.join([str(item) if item not in (None, '') else ' ' for item in row]),
             delimiter
         )

--- a/src/tablib/formats/_jira.py
+++ b/src/tablib/formats/_jira.py
@@ -35,6 +35,16 @@ class JIRAFormat:
     def _serialize_row(cls, row, delimiter='|'):
         return '{}{}{}'.format(
             delimiter,
-            delimiter.join([str(item) if item not in (None, '') else ' ' for item in row]),
+            delimiter.join([' ' if cls._is_empty_value(item) else str(item) for item in row]),
             delimiter
         )
+
+    @classmethod
+    def _is_empty_value(cls, item):
+        if item is None:
+            return True
+        if isinstance(item, (str, bytes, bytearray)):
+            return len(item) == 0
+        if isinstance(item, (list, tuple, dict, set, frozenset)):
+            return len(item) == 0
+        return False

--- a/src/tablib/formats/_latex.py
+++ b/src/tablib/formats/_latex.py
@@ -117,9 +117,20 @@ class LATEXFormat:
         :param row: single dataset row
         """
 
-        new_row = [cls._escape_tex_reserved_symbols(str(item)) if item not in (None, '') else ''
+        new_row = ['' if cls._is_empty_value(item)
+                   else cls._escape_tex_reserved_symbols(str(item))
                    for item in row]
         return 6 * ' ' + ' & '.join(new_row) + ' \\\\'
+
+    @classmethod
+    def _is_empty_value(cls, item):
+        if item is None:
+            return True
+        if isinstance(item, (str, bytes, bytearray)):
+            return len(item) == 0
+        if isinstance(item, (list, tuple, dict, set, frozenset)):
+            return len(item) == 0
+        return False
 
     @classmethod
     def _escape_tex_reserved_symbols(cls, string):

--- a/src/tablib/formats/_latex.py
+++ b/src/tablib/formats/_latex.py
@@ -4,6 +4,8 @@
 """
 import re
 
+from tablib.utils import is_empty_cell
+
 
 class LATEXFormat:
     title = 'latex'
@@ -117,20 +119,10 @@ class LATEXFormat:
         :param row: single dataset row
         """
 
-        new_row = ['' if cls._is_empty_value(item)
+        new_row = ['' if is_empty_cell(item)
                    else cls._escape_tex_reserved_symbols(str(item))
                    for item in row]
         return 6 * ' ' + ' & '.join(new_row) + ' \\\\'
-
-    @classmethod
-    def _is_empty_value(cls, item):
-        if item is None:
-            return True
-        if isinstance(item, (str, bytes, bytearray)):
-            return len(item) == 0
-        if isinstance(item, (list, tuple, dict, set, frozenset)):
-            return len(item) == 0
-        return False
 
     @classmethod
     def _escape_tex_reserved_symbols(cls, string):

--- a/src/tablib/formats/_latex.py
+++ b/src/tablib/formats/_latex.py
@@ -117,7 +117,7 @@ class LATEXFormat:
         :param row: single dataset row
         """
 
-        new_row = [cls._escape_tex_reserved_symbols(str(item)) if item else ''
+        new_row = [cls._escape_tex_reserved_symbols(str(item)) if item not in (None, '') else ''
                    for item in row]
         return 6 * ' ' + ' & '.join(new_row) + ' \\\\'
 

--- a/src/tablib/utils.py
+++ b/src/tablib/utils.py
@@ -1,6 +1,16 @@
 from io import BytesIO, StringIO
 
 
+def is_empty_cell(value):
+    return (
+        value is None
+        or (
+            isinstance(value, (str, bytes, bytearray, list, tuple, dict, set, frozenset))
+            and len(value) == 0
+        )
+    )
+
+
 def normalize_input(stream):
     """
     Accept either a str/bytes stream or a file-like object and always return a

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1777,6 +1777,13 @@ class LatexTests(BaseTestCase):
         output = tablib.Dataset([0, False, 90]).latex
         self.assertIn('0 & False & 90', output)
 
+    def test_latex_export_empty_containers_and_bytes(self):
+        output = tablib.Dataset([[], {}, b'']).latex
+        self.assertIn(' &  & ', output)
+        self.assertNotIn('[]', output)
+        self.assertNotIn('{}', output)
+        self.assertNotIn("b''", output)
+
     def test_latex_escaping(self):
         d = tablib.Dataset(['~', '^'])
         output = d.latex
@@ -1910,6 +1917,10 @@ class JiraTests(BaseTestCase):
     def test_jira_export_falsy_values(self):
         # 0 and False are real values, not empty cells.
         self.assertEqual('|0|False|c|', tablib.Dataset([0, False, 'c']).jira)
+
+    def test_jira_export_empty_containers_and_bytes(self):
+        self.assertEqual('| | |c|', tablib.Dataset([[], {}, 'c']).jira)
+        self.assertEqual('| |c|', tablib.Dataset([b'', 'c']).jira)
 
     def test_jira_export_empty_dataset(self):
         self.assertIsNotNone(tablib.Dataset().jira)

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1772,6 +1772,11 @@ class LatexTests(BaseTestCase):
         self.assertIn('foo', output)
         self.assertNotIn('None', output)
 
+    def test_latex_export_falsy_values(self):
+        # 0 and False are real values and must be rendered, not dropped.
+        output = tablib.Dataset([0, False, 90]).latex
+        self.assertIn('0 & False & 90', output)
+
     def test_latex_escaping(self):
         d = tablib.Dataset(['~', '^'])
         output = d.latex
@@ -1901,6 +1906,10 @@ class JiraTests(BaseTestCase):
 
     def test_jira_export_none_and_empty_values(self):
         self.assertEqual('| | |c|', tablib.Dataset(['', None, 'c']).jira)
+
+    def test_jira_export_falsy_values(self):
+        # 0 and False are real values, not empty cells.
+        self.assertEqual('|0|False|c|', tablib.Dataset([0, False, 'c']).jira)
 
     def test_jira_export_empty_dataset(self):
         self.assertIsNotNone(tablib.Dataset().jira)


### PR DESCRIPTION
The JIRA and LaTeX serializers decide whether a cell is empty with a plain truthiness test:

```python
# _jira.py
delimiter.join([str(item) if item else " " for item in row])
# _latex.py
new_row = [cls._escape_tex_reserved_symbols(str(item)) if item else "" for item in row]
```

So `0`, `0.0`, and `False` — all valid data — are treated as missing and exported as blank cells, silently losing data. For example `tablib.Dataset([0, False, "c"]).jira` produced `| | |c|` instead of `|0|False|c|`.

The HTML format already does this correctly with `str(item) if item is not None else ""`, so "blank only for missing values" is the intended contract. This changes both serializers to test `item not in (None, "")`, which keeps the existing `None`/empty-string behaviour (still rendered blank) while preserving real falsy values.

Added `test_jira_export_falsy_values` and `test_latex_export_falsy_values`; the existing `*_none_*` tests still pass. `pytest -k "jira or latex"` is green (12 passed).