### PR TITLE
Preserve column order in YAML export (#287)

### DIFF
--- a/src/tablib/formats/_yaml.py
+++ b/src/tablib/formats/_yaml.py
@@ -14,14 +14,20 @@ class YAMLFormat:
     def export_set(cls, dataset):
         """Returns YAML representation of Dataset."""
         return yaml.safe_dump(
-            dataset._package(), default_flow_style=None, allow_unicode=True
+            dataset._package(),
+            default_flow_style=None,
+            allow_unicode=True,
+            sort_keys=False,
         )
 
     @classmethod
     def export_book(cls, databook):
         """Returns YAML representation of Databook."""
         return yaml.safe_dump(
-            databook._package(), default_flow_style=None, allow_unicode=True
+            databook._package(),
+            default_flow_style=None,
+            allow_unicode=True,
+            sort_keys=False,
         )
 
     @classmethod

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1709,13 +1709,21 @@ class YAMLTests(BaseTestCase):
 
         self.founders.append(('名字', '李', 60))
         expected = """\
-- {first_name: John, gpa: 90, last_name: Adams}
-- {first_name: George, gpa: 67, last_name: Washington}
-- {first_name: Thomas, gpa: 50, last_name: Jefferson}
-- {first_name: 名字, gpa: 60, last_name: 李}
+- {first_name: John, last_name: Adams, gpa: 90}
+- {first_name: George, last_name: Washington, gpa: 67}
+- {first_name: Thomas, last_name: Jefferson, gpa: 50}
+- {first_name: 名字, last_name: 李, gpa: 60}
 """
         output = self.founders.yaml
         self.assertEqual(output, expected)
+
+    def test_yaml_export_preserves_column_order(self):
+        """YAML export must keep the dataset's column order instead of sorting the keys
+        alphabetically."""
+        data = tablib.Dataset()
+        data.headers = ('name', 'id', 'zebra', 'apple')
+        data.append(('x', 1, 'z', 'a'))
+        self.assertEqual(data.yaml.strip(), '- {name: x, id: 1, zebra: z, apple: a}')
 
     def test_yaml_load(self):
         """ test issue 524: invalid format  """


### PR DESCRIPTION
Fixes #287.

`yaml.safe_dump` sorts mapping keys alphabetically by default, so YAML export reordered columns inconsistently with the CSV and JSON exports (which keep the dataset's header order):

```python
import tablib
d = tablib.Dataset()
d.headers = ["name", "id", "zebra", "apple"]
d.append(["x", 1, "z", "a"])

d.csv.splitlines()[0]   # 'name,id,zebra,apple'
d.yaml                  # before: '- {apple: a, id: 1, name: x, zebra: z}'
                        # after:  '- {name: x, id: 1, zebra: z, apple: a}'
```

This passes `sort_keys=False` when dumping the dataset and the databook, so YAML keeps the original column order (matching CSV/JSON).

`test_yaml_export` is updated to expect header order, and a focused regression test (`test_yaml_export_preserves_column_order`) is added; it fails on `master` (alphabetical) and passes with this change.

---
*Disclosure: prepared with AI assistance; reviewed by me and I can explain every line.*