### PR TITLE
Normalize ragged CSV to the widest row, not the header width

### DIFF
--- a/src/tablib/formats/_csv.py
+++ b/src/tablib/formats/_csv.py
@@ -43,15 +43,28 @@ class CSVFormat:
         kwargs.setdefault('delimiter', cls.DEFAULT_DELIMITER)
 
         rows = csv.reader(in_stream, **kwargs)
+
+        header_row = None
+        data_rows = []
         for i, row in enumerate(rows):
             if i < skip_lines:
                 continue
             if i == skip_lines and headers:
-                dset.headers = row
+                header_row = row
             elif row:
-                if i > 0 and len(row) < dset.width:
-                    row += [''] * (dset.width - len(row))
-                dset.append(row)
+                data_rows.append(row)
+
+        # Ragged rows are normalized to the width of the widest row by filling
+        # in empty elements, not just to the width of the header row (issue #226).
+        width = max((len(r) for r in data_rows), default=0)
+        if header_row is not None:
+            width = max(width, len(header_row))
+            dset.headers = header_row + [''] * (width - len(header_row))
+
+        for row in data_rows:
+            if len(row) < width:
+                row = row + [''] * (width - len(row))
+            dset.append(row)
 
     @classmethod
     def detect(cls, stream, delimiter=None):

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -991,6 +991,30 @@ class CSVTests(BaseTestCase):
             'F |  |  '
         )
 
+    def test_csv_import_set_ragged_wider_than_header(self):
+        """Import ragged CSV where a data row is wider than the header."""
+        csv_text = (
+            "H1,H2\n"
+            "A,B\n"
+            "C,D,E\n"
+        )
+        dataset = tablib.import_set(csv_text, format="csv")
+        self.assertEqual(dataset.headers, ["H1", "H2", ""])
+        self.assertEqual(dataset.width, 3)
+        self.assertEqual(list(dataset[0]), ["A", "B", ""])
+        self.assertEqual(list(dataset[1]), ["C", "D", "E"])
+
+    def test_csv_import_set_ragged_wider_no_headers(self):
+        """Import ragged CSV without headers where a later row is widest."""
+        csv_text = (
+            "A,B\n"
+            "C,D,E\n"
+        )
+        dataset = tablib.import_set(csv_text, format="csv", headers=False)
+        self.assertEqual(dataset.width, 3)
+        self.assertEqual(list(dataset[0]), ["A", "B", ""])
+        self.assertEqual(list(dataset[1]), ["C", "D", "E"])
+
     def test_csv_import_set_skip_lines(self):
         csv_text = (
             'garbage,line\n'


### PR DESCRIPTION
## Summary

CSV import is documented (issue #226) to normalize ragged rows "to the width of the widest row by filling in empty elements". In practice it only pads rows up to the width of the **first/header** row, so a data row *wider* than the header raises `InvalidDimensions`:

```python
>>> import tablib
>>> tablib.import_set("a,b\nc,d,e\n", format="csv")
tablib.exceptions.InvalidDimensions
>>> tablib.import_set("a,b\nc,d,e\n", format="csv", headers=False)
tablib.exceptions.InvalidDimensions
```

The analogous *shorter* case is handled — short rows are padded — so the behaviour is inconsistent, and the existing `test_csv_import_set_ragged` only exercises the header-is-widest direction.

## Fix

Read the header and data rows, compute the width as the maximum across **all** rows (header included), then pad the header and every data row to that width. Empty data lines are still skipped, and an empty/absent header still yields `headers=None`.

```python
>>> dataset = tablib.import_set("a,b\nc,d,e\n", format="csv")
>>> dataset.headers
['a', 'b', '']
>>> list(dataset[0])
['c', 'd', 'e']
```

## Verification

- Reproduced on `master` (`64f0201`): a wider-than-header row raises `InvalidDimensions`; with the fix it normalizes to the widest width (with and without headers).
- Added `test_csv_import_set_ragged_wider_than_header` and `test_csv_import_set_ragged_wider_no_headers`; both fail before the fix and pass after.
- Full suite: **176 passed** (174 baseline + the 2 new tests), no regressions. `ruff check` clean.
- Existing behaviour preserved: shorter-row padding, the empty-line-skipping `test_csv_import_set_ragged`, and empty-stream (`headers=None`) all unchanged.

This completes the ragged-CSV feature from #226 for the wider-row case.

---

This pull request was prepared with the assistance of AI, under my direction and review.
