### PR TITLE
Raise `HeadersNeeded` instead of `TypeError` when subscripting a headerless `Dataset` by column name

### DIFF
--- a/src/tablib/core.py
+++ b/src/tablib/core.py
@@ -176,6 +176,8 @@ class Dataset:
 
     def __getitem__(self, key):
         if isinstance(key, str):
+            if self.headers is None:
+                raise HeadersNeeded()
             if key in self.headers:
                 pos = self.headers.index(key)  # get 'key' index from each data
                 return [row[pos] for row in self._data]
@@ -194,6 +196,8 @@ class Dataset:
 
     def __delitem__(self, key):
         if isinstance(key, str):
+            if self.headers is None:
+                raise HeadersNeeded()
 
             if key in self.headers:
 

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -322,6 +322,20 @@ class TablibTestCase(BaseTestCase):
         # Delete from invalid index
         self.assertRaises(IndexError, self.founders.__delitem__, 3)
 
+    def test_getitem_str_key_no_headers_raises(self):
+        """Verify that accessing by column name on a headerless Dataset raises HeadersNeeded."""
+        d = tablib.Dataset()
+        d.append([1, 2, 3])
+        with self.assertRaises(tablib.core.HeadersNeeded):
+            _ = d['col']
+
+    def test_delitem_str_key_no_headers_raises(self):
+        """Verify that deleting by column name on a headerless Dataset raises HeadersNeeded."""
+        d = tablib.Dataset()
+        d.append([1, 2, 3])
+        with self.assertRaises(tablib.core.HeadersNeeded):
+            del d['col']
+
     def test_str_no_columns(self):
         d = tablib.Dataset(['a', 1], ['b', 2], ['c', 3])
         output = f'{d}'


### PR DESCRIPTION
## Problem

`Dataset.__getitem__` and `Dataset.__delitem__` both evaluate `key in self.headers` when given a string key.  When no headers have been set (`self.headers is None`), Python raises an opaque:

```
TypeError: argument of type 'NoneType' is not iterable
```

instead of the library's own `HeadersNeeded` exception, which every other header-dependent operation (e.g. `sort`, `filter`, `stack_cols`) already raises.

Minimal reproduction:

```python
import tablib
d = tablib.Dataset()
d.append([1, 2, 3])

d["col"]    # TypeError, should be HeadersNeeded
del d["col"]  # TypeError, should be HeadersNeeded
```

## Fix

Add a `self.headers is None` guard at the top of the `isinstance(key, str)` branch in both dunder methods that raises `HeadersNeeded()` before the membership test is attempted.

## Tests

Two new tests added to `DatasetTests`:

- `test_getitem_str_key_no_headers_raises` — verifies `d["col"]` raises `HeadersNeeded`
- `test_delitem_str_key_no_headers_raises` — verifies `del d["col"]` raises `HeadersNeeded`

All 155 tests pass (`test_cli_export_github` deselected as it is a pre-existing failure unrelated to this change).