### PR TITLE
Raise TypeError for invalid Dataset instance

### DIFF
--- a/src/tablib/core.py
+++ b/src/tablib/core.py
@@ -746,7 +746,7 @@ class Dataset:
         ``Dataset`` instance."""
 
         if not isinstance(other, Dataset):
-            return
+            raise TypeError("'other' must be a Dataset instance")
 
         if self.width != other.width:
             raise InvalidDimensions
@@ -769,7 +769,7 @@ class Dataset:
         has headers set, than the other must as well."""
 
         if not isinstance(other, Dataset):
-            return
+            raise TypeError("'other' must be a Dataset instance")
 
         if self.headers or other.headers:
             if not self.headers or not other.headers:

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -502,6 +502,13 @@ class TablibTestCase(BaseTestCase):
         self.assertEqual(column_stacked[0],
                          ("John", "Adams", 90, "John", "Adams", 90))
 
+    def test_stack_rejects_non_dataset(self):
+        """stack() and stack_cols() raise TypeError for non-Dataset input."""
+        with self.assertRaises(TypeError):
+            self.founders.stack('not a dataset')
+        with self.assertRaises(TypeError):
+            self.founders.stack_cols('not a dataset')
+
     def test_sorting(self):
         """Sort columns."""
 


### PR DESCRIPTION
## Problem

`stack()` and `stack_cols()` silently return `None` when passed a non-`Dataset` argument:

```python
ds = tablib.Dataset()
result = ds.stack("not a dataset")
print(result)  # None — caller has no idea the operation failed
```

This makes bugs very hard to diagnose: callers receive `None` without any indication that the argument was invalid.

## Fix

Raise `TypeError` with a clear message instead of silently returning `None`.

```python
ds = tablib.Dataset()
ds.stack("not a dataset")
# TypeError: 'other' must be a Dataset instance
```