### PR TITLE
keep large ints precise in xls/xlsx export

### DIFF
--- a/src/tablib/formats/_xls.py
+++ b/src/tablib/formats/_xls.py
@@ -153,6 +153,9 @@ class XLSFormat:
         for i, row in enumerate(_package):
             for j, col in enumerate(row):
 
+                if isinstance(col, int) and not isinstance(col, bool) and abs(col) > 2**53:
+                    col = str(col)
+
                 # bold headers
                 if (i == 0) and dataset.headers:
                     ws.write(i, j, col, bold)

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -181,6 +181,9 @@ class XLSXFormat:
                     if '\n' in str(col):
                         cell.alignment = wrap_text
 
+                if isinstance(col, int) and not isinstance(col, bool) and abs(col) > 2**53:
+                    col = str(col)
+
                 try:
                     cell.value = col
                 except ValueError:

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1348,6 +1348,20 @@ class XLSTests(BaseTestCase):
         self.assertEqual('h:mm:ss', get_format_str(row[1]))
         self.assertEqual('m/d/yy h:mm', get_format_str(row[2]))
 
+    def test_xls_large_int_kept_precise(self):
+        big = 568883383628111872
+        data.append([big])
+        data.headers = ['id']
+        book = xlrd.open_workbook(file_contents=data.xls)
+        self.assertEqual(str(big), book.sheet_by_index(0).cell_value(1, 0))
+
+    def test_xlsx_large_int_kept_precise(self):
+        big = 568883383628111872
+        data.append([big])
+        data.headers = ['id']
+        book = load_workbook(BytesIO(data.xlsx))
+        self.assertEqual(str(big), book.active['A2'].value)
+
     def test_xls_bad_chars_sheet_name(self):
         """
         Sheet names are limited to 30 chars and the following chars


### PR DESCRIPTION
Fixes #197.

Integers past 2**53 don't fit in Excel's float64 number storage, so they got silently mangled on export — e.g. `568883383628111872` came back as `568883383628112000`.

Following @claudep's suggestion on the issue, values with `abs(col) > 2**53` are now written as text so the digits survive. Normal-sized ints (and bools) are untouched. Applied to both `_xls.py` and `_xlsx.py`, with a test for each.