### PR TITLE
Fix TypeError when stacking two headerless Datasets with stack_cols

### DIFF
--- a/src/tablib/core.py
+++ b/src/tablib/core.py
@@ -789,11 +789,18 @@ class Dataset:
 
         _dset = Dataset()
 
-        for column in self.headers:
-            _dset.append_col(col=self[column])
+        if self.headers:
+            for column in self.headers:
+                _dset.append_col(col=self[column])
 
-        for column in other.headers:
-            _dset.append_col(col=other[column])
+            for column in other.headers:
+                _dset.append_col(col=other[column])
+        else:
+            for index in range(self.width):
+                _dset.append_col(col=self.get_col(index))
+
+            for index in range(other.width):
+                _dset.append_col(col=other.get_col(index))
 
         _dset.headers = new_headers
 

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -523,6 +523,23 @@ class TablibTestCase(BaseTestCase):
         with self.assertRaises(TypeError):
             self.founders.stack_cols('not a dataset')
 
+    def test_column_stacking_headerless(self):
+        """Column stacking two datasets that both have no headers."""
+
+        left = tablib.Dataset()
+        left.append(("x", "y"))
+        left.append(("p", "q"))
+
+        right = tablib.Dataset()
+        right.append(("1", "2", "3"))
+        right.append(("4", "5", "6"))
+
+        column_stacked = left.stack_cols(right)
+
+        self.assertIsNone(column_stacked.headers)
+        self.assertEqual(column_stacked[0], ("x", "y", "1", "2", "3"))
+        self.assertEqual(column_stacked[1], ("p", "q", "4", "5", "6"))
+
     def test_sorting(self):
         """Sort columns."""
 


### PR DESCRIPTION
### Problem

`Dataset.stack_cols()` crashes with an opaque `TypeError` when both datasets have no headers, even though the method is written to allow that case:

```python
>>> import tablib
>>> a = tablib.Dataset(); a.append(("x", "y")); a.append(("p", "q"))
>>> b = tablib.Dataset(); b.append(("1", "2", "3")); b.append(("4", "5", "6"))
>>> a.stack_cols(b)
TypeError: 'NoneType' object is not iterable
```

The method already anticipates two headerless datasets:

- the header guard raises `HeadersNeeded` only when *exactly one* side has headers, and
- the header concatenation catches `None + None` and sets `new_headers = None`.

But it then does `for column in self.headers:` to copy the columns, which iterates `None` and raises. Row-level `stack()` handles headerless datasets fine, so the column-level crash is an internal inconsistency rather than intended behavior.

### Fix

When neither dataset has headers, copy the columns by index with `get_col()` instead of by header name. The existing headered path is unchanged (it is just moved under `if self.headers:`), so headered stacking behaves exactly as before.

### Test

Added `test_column_stacking_headerless`, which stacks two headerless datasets and asserts the combined rows and `headers is None`. It fails on the current code with the `TypeError` above and passes with this change; the existing `test_column_stacking` (headered) still passes.

### Note

This touches the same method as the open PR #649 ("Raise TypeError for invalid Dataset instance"), but a different line: #649 changes the `isinstance(other, Dataset)` guard, while this fixes the headerless column-iteration path. The two do not overlap and either order rebases trivially.
