### PR TITLE
Fix _validate() silently accepting empty rows/cols due to falsy check

### DIFF
--- a/src/tablib/core.py
+++ b/src/tablib/core.py
@@ -255,7 +255,7 @@ class Dataset:
 
     def _validate(self, row=None, col=None, safety=False):
         """Assures size of every row in dataset is of proper proportions."""
-        if row:
+        if row is not None:
             if self.width:
                 is_valid = (
                     len(row) == self.width or
@@ -263,7 +263,7 @@ class Dataset:
                 )
             else:
                 is_valid = True
-        elif col:
+        elif col is not None:
             if len(col) < 1:
                 is_valid = True
             else:


### PR DESCRIPTION
## Summary

`Dataset._validate()` uses `if row:` and `elif col:` to check whether a row or column was passed as an argument. This is a falsy check and fails silently when `row` or `col` is an empty sequence (`()` or `[]`).

When `row=()` is passed (e.g. via `insert()` or `__setitem__()`), the condition `if row:` evaluates to `False`, so execution falls through to the `else` branch, which validates the *entire existing dataset* dimensions instead of checking the incoming row's length. This means **an empty row can be silently inserted into a dataset with existing columns without raising `InvalidDimensions`**.

## Reproduction

```python
import tablib

d = tablib.Dataset()
d.headers = ['a', 'b', 'c']
d.append((1, 2, 3))

# Should raise InvalidDimensions - empty row can't fit a 3-column dataset
d.insert(0, ())   # silently accepted before this fix

# Same issue via __setitem__
d[0] = ()         # silently accepted before this fix
```

## Fix

Replace `if row:` with `if row is not None:` and `elif col:` with `elif col is not None:` so that empty sequences are correctly dispatched to the row/column dimension check instead of the fallback full-dataset check.

## Tests

All 176 existing tests continue to pass. The fix does not change behavior for any non-empty row/col argument.