### PR TITLE
Reject out-of-range column index in Dataset.add_formatter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Here is a list of past and present much-appreciated contributors:
     Andrii Soldatenko
     Benjamin Wohlwend
     Bruno Soares
+    Charles Tonneslan
     Claude Paroz
     Daniel Santos
     Egor Osokin

--- a/src/tablib/core.py
+++ b/src/tablib/core.py
@@ -638,7 +638,7 @@ class Dataset:
             else:
                 raise KeyError
 
-        if col is None or col <= self.width:
+        if col is None or col < self.width:
             self._formatters.append((col, handler))
         else:
             raise InvalidDatasetIndex

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -19,7 +19,7 @@ from openpyxl.reader.excel import load_workbook
 
 import tablib
 from tablib.core import Row, detect_format
-from tablib.exceptions import UnsupportedFormat
+from tablib.exceptions import InvalidDatasetIndex, UnsupportedFormat
 from tablib.formats import registry
 
 try:
@@ -602,6 +602,11 @@ class TablibTestCase(BaseTestCase):
         self.assertEqual(self.founders.dict, expected)
         # Test once more as the result should be the same
         self.assertEqual(self.founders.dict, expected)
+
+    def test_formatter_invalid_column_index(self):
+        """Registering a formatter on an out-of-range index is rejected."""
+        with self.assertRaises(InvalidDatasetIndex):
+            self.founders.add_formatter(self.founders.width, str)
 
     def test_formatters_all_cols(self):
         """


### PR DESCRIPTION
`Dataset.add_formatter` guards the column index with `col <= self.width`, but column indices are 0-based, so the only valid indices are `0 .. width - 1`. The `<=` lets `col == width` — always out of range — slip past the `InvalidDatasetIndex` guard.

The bad index isn't caught at registration; it surfaces later as a raw `IndexError` from `row[col]` when the formatter runs during export:

```python
import tablib

d = tablib.Dataset()
d.headers = ['a', 'b']          # width 2, valid indices 0 and 1
d.append([1, 2])
d.add_formatter(2, lambda v: v * 10)   # index 2 == width, out of range
d.dict                                  # -> IndexError: list index out of range
```

Changing the guard to `col < self.width` rejects the invalid index at registration time with `InvalidDatasetIndex`, as intended. Valid indices, `None` (all columns), and header-name lookups are unaffected. `InvalidDatasetIndex` subclasses `IndexError`, so any caller already catching `IndexError` still works.

Added a regression test and myself to AUTHORS.