### PR TITLE
Fix ODS export of boolean values crashing on re-import

### DIFF
--- a/src/tablib/formats/_ods.py
+++ b/src/tablib/formats/_ods.py
@@ -213,7 +213,9 @@ class ODSFormat:
             odf_row = table.TableRow(stylename=style)
             ws.addElement(odf_row)
             for j, col in enumerate(row):
-                if isinstance(col, numbers.Number):
+                if isinstance(col, bool):
+                    cell = table.TableCell(valuetype="boolean", booleanvalue="true" if col else "false")
+                elif isinstance(col, numbers.Number):
                     cell = table.TableCell(valuetype="float", value=col)
                 elif isinstance(col, dt.datetime):
                     cell = table.TableCell(

--- a/src/tablib/formats/_ods.py
+++ b/src/tablib/formats/_ods.py
@@ -214,7 +214,10 @@ class ODSFormat:
             ws.addElement(odf_row)
             for j, col in enumerate(row):
                 if isinstance(col, bool):
-                    cell = table.TableCell(valuetype="boolean", booleanvalue="true" if col else "false")
+                    cell = table.TableCell(
+                        valuetype="boolean",
+                        booleanvalue="true" if col else "false",
+                    )
                 elif isinstance(col, numbers.Number):
                     cell = table.TableCell(valuetype="float", value=col)
                 elif isinstance(col, dt.datetime):

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1228,8 +1228,8 @@ class ODSTests(BaseTestCase):
         data.headers = ('name', 'flag')
         _ods = data.ods
         data.ods = _ods
-        self.assertTrue(data.dict[0]['flag'])
-        self.assertFalse(data.dict[1]['flag'])
+        for index, expected in ((0, True), (1, False)):
+            self.assertIs(data.dict[index]['flag'], expected)
         self.assertEqual(data.dict[0]['name'], 'alice')
 
     def test_ods_export_display(self):

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1228,8 +1228,8 @@ class ODSTests(BaseTestCase):
         data.headers = ('name', 'flag')
         _ods = data.ods
         data.ods = _ods
-        self.assertIs(data.dict[0]['flag'], True)
-        self.assertIs(data.dict[1]['flag'], False)
+        self.assertTrue(data.dict[0]['flag'])
+        self.assertFalse(data.dict[1]['flag'])
         self.assertEqual(data.dict[0]['name'], 'alice')
 
     def test_ods_export_display(self):

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1222,6 +1222,16 @@ class ODSTests(BaseTestCase):
         self.assertEqual(data.dict[0]['None'], '')
         self.assertEqual(data.dict[0]['empty'], '')
 
+    def test_ods_export_import_boolean(self):
+        data.append(('alice', True))
+        data.append(('bob', False))
+        data.headers = ('name', 'flag')
+        _ods = data.ods
+        data.ods = _ods
+        self.assertIs(data.dict[0]['flag'], True)
+        self.assertIs(data.dict[1]['flag'], False)
+        self.assertEqual(data.dict[0]['name'], 'alice')
+
     def test_ods_export_display(self):
         """Test that exported datetime types are displayed correctly in office software"""
         date = dt.date(2019, 10, 4)

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1228,8 +1228,8 @@ class ODSTests(BaseTestCase):
         data.headers = ('name', 'flag')
         _ods = data.ods
         data.ods = _ods
-        for index, expected in ((0, True), (1, False)):
-            self.assertIs(data.dict[index]['flag'], expected)
+        self.assertIs(data.dict[0]['flag'], True)
+        self.assertIs(data.dict[1]['flag'], False)
         self.assertEqual(data.dict[0]['name'], 'alice')
 
     def test_ods_export_display(self):


### PR DESCRIPTION
## What

Exporting a `Dataset` that contains a boolean to ODS and reading it back crashes:

```python
import tablib
d = tablib.Dataset()
d.headers = ['name', 'flag']
d.append(['alice', True])
d.append(['bob', False])
tablib.Dataset().load(d.export('ods'), 'ods')
# ValueError: could not convert string to float: 'True'
```

In Python `bool` is a subclass of `int`, so a `True`/`False` cell satisfies `isinstance(col, numbers.Number)` in `ODSFormat.dset_sheet` and is written with `valuetype="float"` and `value=True`. odfpy serializes that attribute as the string `"True"`, and on import `read_cell` runs `float("True")` for a `float`-typed cell, raising `ValueError`.

`read_cell` already has a `value_type == 'boolean'` reader, but the export side never produced a boolean-typed cell, so that path was unreachable for tablib's own output.

## Fix

Add a `bool` branch before the `numbers.Number` branch in `dset_sheet` that writes `valuetype="boolean"` with the matching `booleanvalue`, so booleans round-trip back as Python `bool`. The `bool` check must come first because `bool` is a subclass of `int`.

## Test

Added `ODSTests.test_ods_export_import_boolean`, which round-trips `True` and `False` through ODS and asserts they come back as the correct booleans. It fails before the change (`ValueError`) and passes after. The existing numeric/date round-trip test is unaffected.
