### PR TITLE
Only strip the leading '=' when escaping XLSX formulae

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,4 +38,5 @@ Here is a list of past and present much-appreciated contributors:
     Tommy Anthony
     Tsuyoshi Hombashi
     Tushar Makkar
+    Vidit Patankar
     Yunis Yilmaz

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -187,7 +187,7 @@ class XLSXFormat:
                     cell.value = str(col)
 
                 if escape and cell.data_type == 'f' and cell.value.startswith('='):
-                    cell.value = cell.value.replace("=", "")
+                    cell.value = cell.value[1:]
 
     @classmethod
     def _adapt_column_width(cls, worksheet, width):

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1511,6 +1511,16 @@ class XLSXTests(BaseTestCase):
         wb = load_workbook(filename=BytesIO(_xlsx))
         self.assertEqual('SUM(1+1)', wb.active['A1'].value)
 
+    def test_xlsx_export_set_escape_formulae_keeps_inner_equals(self):
+        """
+        Only the leading '=' should be stripped when escaping formulae; '='
+        characters inside the formula (e.g. a comparison) must be preserved.
+        """
+        data.append(('=A1=B1',))
+        _xlsx = data.export('xlsx', escape=True)
+        wb = load_workbook(filename=BytesIO(_xlsx))
+        self.assertEqual('A1=B1', wb.active['A1'].value)
+
     def test_xlsx_export_book_escape_formulae(self):
         """
         Test that formulae are sanitised on export.


### PR DESCRIPTION
### Summary

When exporting XLSX with `escape=True`, formula cells have **every** `=` removed:

```python
cell.value = cell.value.replace("=", "")
```

but the option is documented to remove only the **leading** `=` (`_xlsx.py` docstring: *"formulae will have the leading '=' character removed"*, and the original feature in #540). A legitimate comparison formula like `=A1=B1` is therefore corrupted to `A1B1` instead of `A1=B1`.

Removing just the leading `=` already neutralises the formula (the cell is no longer treated as a formula by Excel), so stripping the inner `=` is unnecessary data loss.

### Fix

Replace `cell.value.replace("=", "")` with `cell.value[1:]`. The leading `=` is guaranteed present by the existing `startswith('=')` guard, so this only drops the leading character. The existing `=SUM(1+1)` → `SUM(1+1)` behaviour is unchanged.

### Test

Added `test_xlsx_export_set_escape_formulae_keeps_inner_equals`: `=A1=B1` with `escape=True` now yields `A1=B1`. It fails before the change (`'A1=B1' != 'A1B1'`) and passes after. All existing escape/XLSX tests still pass. Added myself to `AUTHORS`.

<!-- changelog label: Fixed -->