### PR TITLE
fix: IndexError exporting a zero-width dataset to reStructuredText

### DIFF
--- a/src/tablib/formats/_rst.py
+++ b/src/tablib/formats/_rst.py
@@ -241,7 +241,7 @@ class ReSTFormat:
         True
 
         """
-        if not dataset.dict:
+        if not dataset.dict or not dataset.width:
             return ''
         force_grid = kwargs.get('force_grid', False)
         max_table_width = kwargs.get('max_table_width', cls.MAX_TABLE_WIDTH)

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -909,6 +909,18 @@ class RSTTests(BaseTestCase):
             "==========  =========  ===",
         )
 
+    def test_rst_export_zero_width(self):
+        # A zero-width dataset (rows present, no columns) round-trips through
+        # JSON as '[[]]'; rst must degrade to '' like the other text formats
+        # rather than raising IndexError.
+        data = tablib.import_set('[[]]', format='json')
+        self.assertEqual(data.width, 0)
+        self.assertEqual(data.export('rst'), '')
+
+        data2 = tablib.import_set('[[], []]', format='json')
+        self.assertEqual(data2.width, 0)
+        self.assertEqual(data2.export('rst'), '')
+
 
 class CSVTests(BaseTestCase):
     def test_csv_format_detect(self):


### PR DESCRIPTION
Exporting a zero-width dataset (rows present, no columns) to rst raises `IndexError`. `export_set` guards the empty case with `if not dataset.dict`, but a zero-width dataset has `dict == [[]]` which is truthy, so it falls through to `get_col(0)`/`column_widths[0]` and indexes an empty row.

Such a dataset is valid: `[[]]` is valid JSON that imports cleanly (`import_set` sets `.dict` directly), and every other text format degrades gracefully (csv/tsv give a blank line, json gives `[[]]`, html/latex give an empty table). Only rst crashes. This also returns `''` when the dataset has no columns.

```python
import tablib
tablib.import_set('[[]]', format='json').export('rst')  # IndexError before, '' after
```