### PR TITLE
fix: handle empty and headerless datasets in DBF export

### DIFF
--- a/src/tablib/formats/_dbf.py
+++ b/src/tablib/formats/_dbf.py
@@ -14,6 +14,7 @@ import tempfile
 
 from .._vendor.dbfpy import dbf, dbfnew
 from .._vendor.dbfpy import record as dbfrecord
+from ..exceptions import HeadersNeeded
 
 
 class DBFFormat:
@@ -25,11 +26,14 @@ class DBFFormat:
     @classmethod
     def export_set(cls, dataset):
         """Returns DBF representation of a Dataset"""
+        if dataset.headers is None:
+            raise HeadersNeeded('DBF export requires headers to name the fields.')
         new_dbf = dbfnew.dbf_new()
         temp_file, temp_uri = tempfile.mkstemp()
 
-        # create the appropriate fields based on the contents of the first row
-        first_row = dataset[0]
+        # create the appropriate fields based on the contents of the first row;
+        # with no rows, field types cannot be inferred so default to character
+        first_row = dataset[0] if dataset.height else [None] * len(dataset.headers)
         for fieldname, field_value in zip(dataset.headers, first_row):
             if type(field_value) in [int, float]:
                 new_dbf.add_field(fieldname, 'N', 10, 8)

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -19,7 +19,7 @@ from openpyxl.reader.excel import load_workbook
 
 import tablib
 from tablib.core import Row, detect_format
-from tablib.exceptions import UnsupportedFormat
+from tablib.exceptions import HeadersNeeded, UnsupportedFormat
 from tablib.formats import registry
 
 try:
@@ -1952,6 +1952,26 @@ class DBFTests(BaseTestCase):
         self.assertFalse(fmt.detect(_csv))
         self.assertFalse(fmt.detect(_json))
         self.assertFalse(fmt.detect(_bunk))
+
+    def test_dbf_export_headers_only(self):
+        # A dataset with headers but no rows exports to a valid dbf (field
+        # types default to character) instead of raising IndexError.
+        data = tablib.Dataset()
+        data.headers = ['name', 'gpa']
+        blob = data.export('dbf')
+
+        roundtrip = tablib.Dataset()
+        roundtrip.load(blob, format='dbf')
+        self.assertEqual(roundtrip.headers, ['NAME', 'GPA'])
+        self.assertEqual(roundtrip.height, 0)
+
+    def test_dbf_export_without_headers_raises(self):
+        # dbf needs field names; a headerless dataset must raise HeadersNeeded
+        # rather than leaking a raw TypeError.
+        data = tablib.import_set('[[1, 2], [3, 4]]', format='json')
+        self.assertIsNone(data.headers)
+        with self.assertRaises(HeadersNeeded):
+            data.export('dbf')
 
 
 class JiraTests(BaseTestCase):


### PR DESCRIPTION
DBF `export_set` inferred each field's type from `dataset[0]`. On a headers-only dataset (columns defined, no rows) that raised `IndexError`, and because the function never checked for headers, a headerless dataset raised a raw `TypeError: 'NoneType' object is not iterable` from `zip(dataset.headers, ...)`.

Two changes: default field types to character when there are no rows (a headers-only dataset now exports to a valid dbf that round-trips), and raise `HeadersNeeded` when the dataset has no headers, since dbf fields must be named (matches the `HeadersNeeded` pattern used elsewhere rather than leaking a TypeError).

```python
import tablib
d = tablib.Dataset(); d.headers = ['name', 'gpa']
d.export('dbf')  # IndexError before, valid dbf after
tablib.import_set('[[1,2]]', format='json').export('dbf')  # TypeError before, HeadersNeeded after
```