### PR TITLE
Don't silently corrupt large integers when exporting to XLS/XLSX

### DIFF
--- a/src/tablib/formats/_xls.py
+++ b/src/tablib/formats/_xls.py
@@ -12,6 +12,7 @@ import xlwt
 from xlrd.xldate import xldate_as_datetime
 
 import tablib
+from tablib.utils import spreadsheet_safe_value
 
 # special styles
 wrap = xlwt.easyxf("alignment: wrap on")
@@ -174,6 +175,7 @@ class XLSFormat:
                     ws.write(i, j, col, time_style)
                 # wrap the rest
                 else:
+                    col = spreadsheet_safe_value(col)
                     try:
                         if '\n' in col:
                             ws.write(i, j, col, wrap)

--- a/src/tablib/formats/_xlsx.py
+++ b/src/tablib/formats/_xlsx.py
@@ -20,6 +20,7 @@ from openpyxl.utils import get_column_letter
 from openpyxl.workbook import Workbook
 
 import tablib
+from tablib.utils import spreadsheet_safe_value
 
 INVALID_TITLE_REGEX = re.compile(r'[\\*?:/\[\]]')
 
@@ -181,6 +182,7 @@ class XLSXFormat:
                     if '\n' in str(col):
                         cell.alignment = wrap_text
 
+                col = spreadsheet_safe_value(col)
                 try:
                     cell.value = col
                 except ValueError:

--- a/src/tablib/utils.py
+++ b/src/tablib/utils.py
@@ -2,6 +2,11 @@ __lazy_modules__ = {"io"}
 
 from io import BytesIO, StringIO
 
+# The largest (and, by symmetry, smallest) integer magnitude that can be
+# represented exactly as an IEEE-754 double, which is how spreadsheet
+# formats such as XLS and XLSX store numeric cell values internally.
+MAX_EXACT_INT_IN_DOUBLE = 2 ** 53
+
 
 def normalize_input(stream):
     """
@@ -13,3 +18,24 @@ def normalize_input(stream):
     elif isinstance(stream, bytes):
         return BytesIO(stream)
     return stream
+
+
+def spreadsheet_safe_value(value):
+    """
+    Return ``value`` unchanged, unless it's an ``int`` too large to be
+    represented exactly as an IEEE-754 double -- the numeric storage used
+    internally by spreadsheet formats like XLS and XLSX. In that case,
+    return the value's exact decimal string representation instead, so
+    that writing it to a spreadsheet doesn't silently corrupt it into a
+    nearby, incorrect number.
+
+    ``bool`` is intentionally excluded, since it's a subclass of ``int``
+    but should keep its normal boolean handling.
+    """
+    if (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and abs(value) > MAX_EXACT_INT_IN_DOUBLE
+    ):
+        return str(value)
+    return value

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1396,6 +1396,31 @@ class XLSTests(BaseTestCase):
         self.assertEqual('h:mm:ss', get_format_str(row[1]))
         self.assertEqual('m/d/yy h:mm', get_format_str(row[2]))
 
+    def test_xls_export_large_int_precision(self):
+        """Regression test for
+        https://github.com/jazzband/tablib/issues/197
+
+        Large integers exceeding the range exactly representable by an
+        IEEE-754 double (the numeric storage XLS uses internally) must
+        not be silently corrupted into a nearby, incorrect value. They
+        should round-trip exactly, even if that means storing them as
+        text rather than as a spreadsheet "number".
+        """
+        big_int = 123456789012345677  # not exactly representable as a double
+        data.headers = ('test_id',)
+        data.append((big_int,))
+        _xls = data.xls
+        xls_book = xlrd.open_workbook(file_contents=_xls)
+        cell_value = xls_book.sheet_by_index(0).cell_value(1, 0)
+        self.assertEqual(str(cell_value), str(big_int))
+
+        # Small, normal-range integers must remain untouched (still
+        # numeric, not converted to strings).
+        data2 = tablib.Dataset(headers=('n',))
+        data2.append((42,))
+        xls_book2 = xlrd.open_workbook(file_contents=data2.xls)
+        self.assertEqual(xls_book2.sheet_by_index(0).cell_value(1, 0), 42)
+
     def test_xls_bad_chars_sheet_name(self):
         """
         Sheet names are limited to 30 chars and the following chars
@@ -1522,6 +1547,25 @@ class XLSXTests(BaseTestCase):
         with xls_source.open('rb') as fh:
             data = tablib.Dataset().load(fh)
         self.assertEqual(data.headers[0], 'Hello World')
+
+    def test_xlsx_export_large_int_precision(self):
+        """Regression test for
+        https://github.com/jazzband/tablib/issues/197 (XLSX side of the
+        same underlying issue as test_xls_export_large_int_precision).
+        """
+        big_int = 123456789012345677  # not exactly representable as a double
+        data.headers = ('test_id',)
+        data.append((big_int,))
+        _xlsx = data.xlsx
+        wb = load_workbook(filename=BytesIO(_xlsx))
+        cell_value = wb.active['A2'].value
+        self.assertEqual(str(cell_value), str(big_int))
+
+        # Small, normal-range integers must remain untouched.
+        data2 = tablib.Dataset(headers=('n',))
+        data2.append((42,))
+        wb2 = load_workbook(filename=BytesIO(data2.xlsx))
+        self.assertEqual(wb2.active['A2'].value, 42)
 
     def test_xlsx_export_set_escape_formulae(self):
         """


### PR DESCRIPTION
Fixes #197.

Both the legacy XLS format (via `xlwt`) and XLSX (via `openpyxl`) store numeric cell values internally as IEEE-754 doubles, which can only represent integers exactly up to `2**53` in magnitude. Writing a larger integer as a numeric cell silently rounds it to the nearest representable double -- e.g. `123456789012345677` becomes `123456789012345680` on read-back -- a wrong value with no error or warning, as reported in the issue (which showed the same class of corruption with a different example integer).

This is a fundamental limitation of both spreadsheet formats' numeric storage, not something fixable while keeping the cell as a spreadsheet "number" -- it affects any writer for these formats (Excel itself included). The reasonable, uncontroversial fix is to detect when an integer's magnitude exceeds what a double can represent exactly and, only in that case, write it as its exact decimal string instead of silently writing a wrong number. Integers within the safe range are completely unaffected and remain numeric cells, exactly as before.

**Implementation**: added a shared `spreadsheet_safe_value()` helper in `tablib.utils` (`bool` is explicitly excluded, since it's an `int` subclass but should keep its normal boolean handling), and applied it at the one cell-writing call site in each of `_xls.py` and `_xlsx.py`.

**Testing**: added a regression test for each format that reproduces the exact corruption with a large integer. I picked a value that's genuinely *not* exactly representable as a double -- the original issue's example number turned out to have enough trailing zero bits in binary to round-trip correctly on its own, which I discovered by computing its required mantissa bits, so I used a different value that reliably demonstrates the general bug class. Both new tests fail with the original code (reproducing the exact reported-style corruption) and pass with the fix. Also verified small, normal-range integers are completely untouched (still numeric cells, not converted to strings).

Ran the full existing test suite: 182 passed (180 baseline + 2 new), no regressions.