### PR TITLE
Fix ValueError exporting an rst table with an all-empty column and no headers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Here is a list of past and present much-appreciated contributors:
     Nicholas Pilon
     Peyman Salehi
     Rabin Nankhwa
+    Sarath Francis
     Tak Hogan
     Tommy Anthony
     Tsuyoshi Hombashi

--- a/src/tablib/formats/_rst.py
+++ b/src/tablib/formats/_rst.py
@@ -104,8 +104,9 @@ class ReSTFormat:
             column_widths = (lens for lens in median_lens)
         # Allow for separator and padding:
         column_widths = (w - pad_len if w > pad_len else w for w in column_widths)
-        # Rather widen table than break words:
-        column_widths = [max(w, l) for w, l in zip(column_widths, word_lens)]
+        # Rather widen table than break words, but keep at least one character
+        # so a column of only empty cells still has a valid, non-zero width:
+        column_widths = [max(w, l, 1) for w, l in zip(column_widths, word_lens)]
         return column_widths
 
     @classmethod

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -909,6 +909,21 @@ class RSTTests(BaseTestCase):
             "==========  =========  ===",
         )
 
+    def test_rst_export_empty_column_without_headers(self):
+        # A column that is empty in every row gives that column a width of 0
+        # when there are no headers to enforce a minimum. That used to raise
+        # "ValueError: invalid width 0 (must be > 0)" while wrapping the cells.
+        data = tablib.Dataset()
+        data.append(('', 'a'))
+        data.append(('', 'b'))
+        self.assertEqual(
+            data.export('rst'),
+            '=  =\n'
+            '   a\n'
+            '   b\n'
+            '=  ='
+        )
+
 
 class CSVTests(BaseTestCase):
     def test_csv_format_detect(self):


### PR DESCRIPTION
Exporting a headerless `Dataset` to rst blows up with `ValueError: invalid width 0 (must be > 0)` whenever one column is empty in every row:

```python
import tablib
data = tablib.Dataset()
data.append(('', 'a'))
data.append(('', 'b'))
data.export('rst')   # ValueError before this change
```

That column ends up with a computed width of 0 (there's no header to give it a minimum), and `TextWrapper` refuses to wrap text at width 0. I clamp every column to at least one character wide, so the empty column just renders as blank cells inside a normal border. Columns that already have content are unaffected.

This is a different failure mode from the zero-column dataset in #659: there the dataset has no columns at all and raises `IndexError`, whereas here the dataset does have columns and one of them simply happens to be empty.

I added a test that reproduces the crash and checks the rendered table. The full test suite and ruff both pass.