### PR TITLE
Convert XLS cell values when importing a Databook

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,4 +39,5 @@ Here is a list of past and present much-appreciated contributors:
     Tsuyoshi Hombashi
     Tushar Makkar
     Vidit Patankar
+    Vineeth Sai
     Yunis Yilmaz

--- a/src/tablib/formats/_xls.py
+++ b/src/tablib/formats/_xls.py
@@ -93,22 +93,19 @@ class XLSFormat:
         return stream.getvalue()
 
     @classmethod
-    def import_set(cls, dset, in_stream, headers=True, skip_lines=0):
-        """Returns databook from XLS stream."""
+    def read_cell(cls, value, type_, datemode):
+        """Returns the Python value of a cell, based on its xlrd type."""
+        if type_ == xlrd.XL_CELL_ERROR:
+            return xlrd.error_text_from_code[value]
+        elif type_ == xlrd.XL_CELL_DATE:
+            return xldate_as_datetime(value, datemode)
+        return value
 
-        dset.wipe()
-
-        xls_book = xlrd.open_workbook(file_contents=in_stream.read())
-        sheet = xls_book.sheet_by_index(0)
+    @classmethod
+    def import_sheet(cls, dset, sheet, datemode, headers=True, skip_lines=0):
+        """Populates dataset with sheet."""
 
         dset.title = sheet.name
-
-        def cell_value(value, type_):
-            if type_ == xlrd.XL_CELL_ERROR:
-                return xlrd.error_text_from_code[value]
-            elif type_ == xlrd.XL_CELL_DATE:
-                return xldate_as_datetime(value, xls_book.datemode)
-            return value
 
         for i in range(sheet.nrows):
             if i < skip_lines:
@@ -117,9 +114,20 @@ class XLSFormat:
                 dset.headers = sheet.row_values(i)
             else:
                 dset.append([
-                    cell_value(val, typ)
+                    cls.read_cell(val, typ, datemode)
                     for val, typ in zip(sheet.row_values(i), sheet.row_types(i))
                 ])
+
+    @classmethod
+    def import_set(cls, dset, in_stream, headers=True, skip_lines=0):
+        """Returns databook from XLS stream."""
+
+        dset.wipe()
+
+        xls_book = xlrd.open_workbook(file_contents=in_stream.read())
+        sheet = xls_book.sheet_by_index(0)
+
+        cls.import_sheet(dset, sheet, xls_book.datemode, headers, skip_lines)
 
     @classmethod
     def import_book(cls, dbook, in_stream, headers=True):
@@ -130,16 +138,9 @@ class XLSFormat:
         xls_book = xlrd.open_workbook(file_contents=in_stream.read())
 
         for sheet in xls_book.sheets():
-            data = tablib.Dataset()
-            data.title = sheet.name
-
-            for i in range(sheet.nrows):
-                if i == 0 and headers:
-                    data.headers = sheet.row_values(0)
-                else:
-                    data.append(sheet.row_values(i))
-
-            dbook.add_sheet(data)
+            dset = tablib.Dataset()
+            cls.import_sheet(dset, sheet, xls_book.datemode, headers)
+            dbook.add_sheet(dset)
 
     @classmethod
     def dset_sheet(cls, dataset, ws):

--- a/tests/test_tablib.py
+++ b/tests/test_tablib.py
@@ -1374,6 +1374,30 @@ class XLSTests(BaseTestCase):
             }
         )
 
+    def test_xls_book_date_import(self):
+        """Dates are converted when a book is imported, as they are for a set."""
+        xls_source = Path(__file__).parent / 'files' / 'dates.xls'
+        with xls_source.open('rb') as fh:
+            dbook = tablib.Databook().load(fh, 'xls')
+        self.assertEqual(
+            dbook.sheets()[0].dict[0]['birth_date'], dt.datetime(2015, 4, 12, 0, 0)
+        )
+
+    def test_xls_book_import_with_errors(self):
+        """Errors are kept as errors when a book is imported, as they are for a set."""
+        xls_source = Path(__file__).parent / 'files' / 'errors.xls'
+        with xls_source.open('rb') as fh:
+            dbook = tablib.Databook().load(fh, 'xls')
+        self.assertEqual(
+            dbook.sheets()[0].dict[0],
+            {
+                'div by 0': '#DIV/0!',
+                'name unknown': '#NAME?',
+                'not available (formula)': '#N/A',
+                'not available (static)': '#N/A',
+            }
+        )
+
     def test_book_import_from_stream(self):
         in_stream = self.founders.xls
         book = tablib.Databook().load(in_stream, 'xls')


### PR DESCRIPTION
## The bug

`XLSFormat.import_set` reads cells through a `cell_value` helper that turns Excel date serials into `datetime` objects and error codes into strings like `#N/A`. `XLSFormat.import_book` re-implemented the row loop with raw `sheet.row_values(i)` and never got that helper, so the same file returns different values depending on whether you load it as a `Dataset` or a `Databook`.

Using the fixtures already in the test suite:

```
dates.xls    'birth_date'
   Dataset  -> datetime.datetime(2015, 4, 12, 0, 0)
   Databook -> 42106.0

errors.xls   'not available (formula)'
   Dataset  -> '#N/A'
   Databook -> 42
```

That `42` is the symptom from #202 ("Tablib import Excel NA() values as 42"), which was fixed on the `import_set` path only; it still reproduces today through `Databook`.

XLS is the only spreadsheet format where the two paths differ. Both XLSX and ODS delegate `import_set` and `import_book` to a shared `import_sheet`, so they cannot drift. The existing `test_xls_date_import` and `test_xls_import_with_errors` assert the converted values, but only via `Dataset`, and the one XLS Databook test only checks a sheet title, which is why this went unnoticed.

## The fix

Extract an `import_sheet` classmethod and call it from both entry points, mirroring the structure `_xlsx.py` and `_ods.py` already use. The cell conversion becomes a `read_cell` classmethod, matching the `read_cell` in `_ods.py`, with the workbook `datemode` passed in explicitly rather than captured from an enclosing scope (`sheet.book` is not reliable under xlrd's `on_demand`).

Header handling is deliberately unchanged. `import_set` reads headers with raw `row_values` today and the shared helper keeps doing that, so `Databook` now matches `Dataset` exactly rather than changing both.

## Tests

Two regression tests load the existing `dates.xls` and `errors.xls` fixtures as a `Databook` and assert the same values the `Dataset` tests already assert. Both fail before this change (`42106.0 != datetime.datetime(2015, 4, 12, 0, 0)`) and pass after.

```
$ pytest tests/ -q
182 passed
```

Full suite passes before and after; the count goes from 180 to 182 with the two new tests. Added myself to `AUTHORS` per the contributing guide.
